### PR TITLE
require.paths depreciated

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -12,7 +12,12 @@ var config = require('./config').load()
 ;
 
 // expose current directory to plugins
-require.paths.unshift('.');
+try {
+    require.paths.unshift('.');
+} catch(e) {
+    // no longer supported
+    console.warn(e.message);
+}
 
 // load plugins
 plugins.forEach(function(fd) {


### PR DESCRIPTION
wrapped the require.paths in a try/catch block in case it is needed in an older version of node.js... I am running v0.6.4 on windows, this was my only hangup to getting it to launch.
