### PR TITLE
fix garbled arrays in posted JSON data

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -198,7 +198,7 @@ function wrapAsyncFunctions(asyncFunctions, sandbox, events, done, sandboxRoot) 
           return result;
         }
       };
-    } else if (typeof asyncFunctions[k] === 'object') {
+    } else if (typeof asyncFunctions[k] === 'object' && !(asyncFunctions[k] instanceof Array)) {
       sandbox[k] = sandbox[k] || {};
       wrapAsyncFunctions(asyncFunctions[k], sandbox[k], events, done, sandboxRoot);
     } else {


### PR DESCRIPTION
When posted JSON data contained arrays the wrapAsyncFuntions function in lib/script.js accidentally transformed these into objects, thereby garbling the script context's body property.
