### PR TITLE
Node v0.10 will warning fs.writeFile without callback

### DIFF
--- a/bin/dpd
+++ b/bin/dpd
@@ -357,7 +357,7 @@ function checkForUpdates() {
 
       if (json && json['dist-tags'] && json['dist-tags'].latest) {
         var latest = json['dist-tags'].latest;
-        fs.writeFile(latestversionFile, latest);
+        fs.writeFile(latestversionFile, latest, function () {});
       }
     }
   });


### PR DESCRIPTION
``` bash
hello-world jacksontian $ dpd
starting deployd v0.6.10...
listening on port 2403
type help for a list of commands
dpd > fs: missing callback Error: EACCES, open '/usr/local/lib/node_modules/deployd/.latestversion'
```
