### PR TITLE
improve session

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -101,7 +101,11 @@ UserCollection.prototype.handle = function (ctx) {
 
             if(hash === uc.hash(credentials.password, salt)) {
               debug('logged in as %s', credentials.username);
-              ctx.session.set({path: path, uid: user.id}).save(ctx.done);
+							var sessionData = {path: path, uid: user.id};
+							for(var key in ctx.req.body) {
+								sessionData[key] = ctx.req.body[key];
+							}
+              ctx.session.set(sessionData).save(ctx.done);
               return;
             }
           }

--- a/lib/script.js
+++ b/lib/script.js
@@ -63,7 +63,8 @@ Script.prototype.run = function (ctx, domain, fn) {
         data = query;
         if(session.emitToAll) session.emitToAll(event, data);
       }
-    }
+    },
+		session: session && session.data
   };
   
   scriptContext._this = scriptContext['this'];
@@ -117,9 +118,19 @@ Script.prototype.run = function (ctx, domain, fn) {
     scriptContext._error = err;
   }
   err = err || scriptContext._error;
+	
   process.nextTick(function () {
     if (callbackCount <= 0) {
-      done(err);
+			if(err) return done(err)
+		  if(session && session.data && session.data.uid) {
+				session.set(scriptContext.session).save(function(){
+					// console.log('scriptContext.session:',scriptContext.session)
+					// console.log('session:', session.data)
+					done(err)
+				})
+			} else {
+				done(err)
+			}
     }
   });
 };

--- a/test-app/node_modules/hello.js
+++ b/test-app/node_modules/hello.js
@@ -1,4 +1,4 @@
-var Resource = require('deployd/lib/resource')
+var Resource = require('../../lib/resource')
   , util = require('util');
 
 function Hello(settings) {

--- a/test-app/node_modules/proxy/index.js
+++ b/test-app/node_modules/proxy/index.js
@@ -2,7 +2,7 @@
  * example custom resource
  */
 
-var Resource = require('deployd/lib/resource')
+var Resource = require('../../../lib/resource')
   , util = require('util')
   , request = require('request');
 

--- a/test-app/public/test/user-collection.test.js
+++ b/test-app/public/test/user-collection.test.js
@@ -92,6 +92,38 @@ describe('User Collection', function() {
 				});
 			});
 		});
+		describe('dpd.session', function(){
+		  it('should save login body info on session', function(done){
+				dpd.users.post(credentials, function (user, err) {
+					expect(user.id.length).to.equal(16);
+					var body = {role:'owner'}
+					Object.keys(credentials).forEach(function(key){
+						body[key] = credentials[key]
+					})
+					dpd.users.login(body, function (session, err) {
+						expect(session.id.length).to.equal(128);
+						expect(session.uid.length).to.equal(16);
+						expect(session).to.have.property('role', 'owner')
+						done(err);
+					});
+				})		    
+		  })
+			
+			it('should modify session data', function(done){
+				dpd.users.post(credentials, function (user, err) {
+					expect(user.id.length).to.equal(16);
+					dpd.users.login(credentials, function (session, err) {
+						dpd.users.get(function(result, err){
+			        dpd.todos.post({title: 'faux'}, function (todo, err) {
+								console.log('session2:', todo)
+								expect(todo.tags).to.contain(2)
+								done(err)
+			        });
+						})
+					});
+				})		    
+			})
+		})
 		describe('.del({id: \'...\'}, fn)', function() {
 			it('should remove a user', function(done) {
 				dpd.users.post(credentials, function (user, err) {

--- a/test-app/resources/todos/post.js
+++ b/test-app/resources/todos/post.js
@@ -1,3 +1,11 @@
+if(session && session.uid) {
+    console.log('TODOS:', session);
+    session.count = session.count || 0;
+    session.count++;
+    this.tags = this.tags||[];
+    this.tags.push(session.count);
+}
+
 if (this.title == "$REQUIRE_AUTH") {
     if (!me) cancel("You are not authorized", 401);
 }

--- a/test-app/resources/users/get.js
+++ b/test-app/resources/users/get.js
@@ -1,3 +1,9 @@
 dpd.users.get({id: {$in: this.friends}}, function(friends) {
     if (friends) this.friends = friends;
 });
+
+if(session && session.uid) {
+    session.count = session.count || 0;
+    session.count++;
+    console.log('Session Test:', session);
+}


### PR DESCRIPTION
#1. Save body info when login

```
POST /users/login
{
  "username": "johnsmith",
  "password": "password",
  "role": "owner"
}
```

`role` will be save into `ctx.session`
#2. Access from On Event Script

add session variable on scriptContent

```
OnGet /users
session.count = session.count || 0;
session.count++;
```

Then we can 

```
OnPost /todos
console.log(session.count)
```
