### PR TITLE
set mongodb config file to null device

### DIFF
--- a/lib/util/mongod.js
+++ b/lib/util/mongod.js
@@ -8,7 +8,6 @@ var fs = require('fs')
 
 exports.restart = function (mongod, env, port, fn) {
   var pid;
-  var null_device;
 
   debug('starting %s', mongod);
 
@@ -24,13 +23,11 @@ exports.restart = function (mongod, env, port, fn) {
     }
   } catch(e) {}
 
-  //sets the platform-specific null device
-  if (process.platform.match(/linux|freebsd|darwin|sunos/) !== null) {
-    var null_device = '/dev/null'
-  } else if (process.platform.match(/win32/) !== null) {
-    var null_device = 'NUL'
-  }
-  var options =  ['--dbpath', './data', '--pidfilepath', './.dpd/pids/mongod', '--port', port, '-f', null_device];
+  /*! 
+  * The mongodb config file is set to the platform-specific null device in order to override the default options of mongodb in 
+  * Homebrew and similar distributions.
+  */
+  var options =  ['--dbpath', './data', '--pidfilepath', './.dpd/pids/mongod', '--port', port, '-f', fs.existsSync('/dev/null') ? '/dev/null' : 'NUL' ];
   if(env === 'development') {
     options.push('--nojournal');
     options.push('--smallfiles');


### PR DESCRIPTION
Hi, 
  I've added code to lib/util/mongod.js to determine the platform specific null device and set the mongod config
  file to it. This will prevent abnormal behavior when mongodb is installed with homebrew and other repositories
  that set a "mongod" script in the system path.

Regards,

Sebastian.
