### PR TITLE
Fixed error caused by incorrect main property in package.json

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -35,11 +35,17 @@ module.exports = function loadTypes(basepath, fn) {
               process.nextTick(function () {
                 remaining--;
                 try {
-                  debug('Loading', require('path').resolve(path) + '/node_modules/' + file);
-                  var c = require(require('path').resolve(path) + '/node_modules/' + file);
-                  if(c && c.prototype && c.prototype.__resource__) {
-                    debug('is a resource ', c && c.name);
-                    types[c.name] = c; 
+                  var moduleMain = require('path').resolve(path) + '/node_modules/' + file;
+                  debug('Loading', moduleMain);
+                  var stats = fs.lstatSync(moduleMain);
+                  if ( stats.isFile() ) {
+                    var c = require(moduleMain);
+                    if(c && c.prototype && c.prototype.__resource__) {
+                      debug('is a resource ', c && c.name);
+                      types[c.name] = c;
+                    }
+                  } else {
+                    debug('Does not exist: ', moduleMain);
                   }
                 } catch(e) { 
                   console.error();


### PR DESCRIPTION
type-loader.js attempts to require all modules to find resources that might be included with the modules. This causes a problem when the main entry point for the package is incorrect

Here is an example of the kinds of errors that occur

Error loading module node_modules/grunt-concurrent
Error: Cannot find module '/Users/taras/Repositories/re-furniture.net/node_modules/grunt-concurrent'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/taras/Repositories/re-furniture.net/node_modules/deployd/lib/type-loader.js:39:27
    at process._tickDomainCallback (node.js:459:13)

Error loading module node_modules/grunt-nodemon
Error: Cannot find module '/Users/taras/Repositories/re-furniture.net/node_modules/grunt-nodemon'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/taras/Repositories/re-furniture.net/node_modules/deployd/lib/type-loader.js:39:27
    at process._tickDomainCallback (node.js:459:13)

Error loading module node_modules/grunt-shell
Error: Cannot find module '/Users/taras/Repositories/re-furniture.net/node_modules/grunt-shell'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/taras/Repositories/re-furniture.net/node_modules/deployd/lib/type-loader.js:39:27
    at process._tickDomainCallback (node.js:459:13)

Error loading module node_modules/grunt-svgmin
Error: Cannot find module '/Users/taras/Repositories/re-furniture.net/node_modules/grunt-svgmin'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/taras/Repositories/re-furniture.net/node_modules/deployd/lib/type-loader.js:39:27
    at process._tickDomainCallback (node.js:459:13)

Error loading module node_modules/grunt-usemin
Error: Cannot find module '/Users/taras/Repositories/re-furniture.net/node_modules/grunt-usemin'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/taras/Repositories/re-furniture.net/node_modules/deployd/lib/type-loader.js:39:27
    at process._tickDomainCallback (node.js:459:13)
