### PR TITLE
Added directories to valid paths for require()

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -47,12 +47,15 @@ module.exports = function loadTypes(basepath, fn) {
                   } else {
                     debug('Does not exist: ', moduleMain);
                   }
-                } catch(e) { 
-                  console.error();
-                  console.error("Error loading module node_modules/" + file);
-                  console.error(e.stack || e);
-                  if(process.send) process.send({moduleError: e || true});
-                  process.exit(1);
+                } catch(e) {
+                  // ignore errors from modules with incorrect main property in their package.json
+                  if (e && e.code !== 'MODULE_NOT_FOUND') {
+                    console.error();
+                    console.error("Error loading module node_modules/" + file);
+                    console.error(e.stack || e);
+                    if(process.send) process.send({moduleError: e || true});
+                    process.exit(1);
+                  }
                 }
               
                 if(remaining === 0) {


### PR DESCRIPTION
Fix #245 and #240
Modules contained in directories are skipped so just added checking for directory also.
Modules with incorrect main entry points in their _package.json_ throws `Error` with code property set to  `'MODULE_NOT_FOUND'`, so IMO it would be better to just ignore incorrect modules.
