### PR TITLE
Added support for mongodb $addToSet but named its syntax to $addUnique

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -682,7 +682,11 @@ Collection.prototype.execCommands = function (type, obj, commands) {
               if(Array.isArray(obj[key])) {
                 obj[key] = _.union(obj[key], val);
               } else {
-                obj[key] = [val];
+                if (Array.isArray(val)) {
+                  obj[key] = val;
+                } else {
+                  obj[key] = [val];
+                }
               }
             }
           });

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -616,6 +616,47 @@ describe('Collection', function() {
 
     });
 
+    describe('.put(id, {tags: {$addUnique: ["yellow", "magenta", "violet"]}}, fn)', function() {
+      it('should update a set', function(done) {
+        chain(function(next) {
+          dpd.todos.post({title: 'foobar', tags: ['red', 'blue', 'green']}, next);
+        }).chain(function(next, result) {
+          dpd.todos.put(result.id, {tags: {$addUnique: ["yellow", "magenta", "violet"]}}, next);
+        }).chain(function(next, result) {
+          expect(result.tags.length).to.equal(6);
+          expect(result.tags).to.include("red").and.include("blue").and.include("green")
+            .and.include("yellow").and.include("magenta").and.include("violet");
+          done();
+        });
+      });
+
+      it('should update an empty array', function(done) {
+        chain(function(next) {
+          dpd.todos.post({title: 'foobar'}, next);
+        }).chain(function(next, result) {
+          dpd.todos.put(result.id, {tags: {$addUnique: ["yellow", "magenta", "violet"]}}, next);
+        }).chain(function(next, result) {
+          expect(result.tags.length).to.equal(3);
+          expect(result.tags).to.include("yellow").and.include("magenta").and.include("violet");
+          done();
+        });
+      });
+
+      it('should not update a set if element already exists', function(done) {
+        chain(function(next) {
+          dpd.todos.post({title: 'foobar', tags: ['red', 'blue', 'green', 'yellow', 'magenta']}, next);
+        }).chain(function(next, result) {
+          dpd.todos.put(result.id, {tags: {$addUnique: ["yellow", "magenta", "violet"]}}, next);
+        }).chain(function(next, result) {
+          expect(result.tags.length).to.equal(6);
+          expect(result.tags).to.include("red").and.include("blue").and.include("green")
+            .and.include("yellow").and.include("magenta").and.include("violet");
+          done();
+        });
+      });
+
+    });
+
     describe('.put({done: true})', function(){
       it('should not update multiple items', function(done) {
         chain(function(next) {

--- a/test/collection.unit.js
+++ b/test/collection.unit.js
@@ -203,7 +203,7 @@ describe('collection', function(){
     });
 
     it('should pass $addUnique command', function(done) {
-      var c = new Collection('counts', {db: db.create(TEST_DB), config: { properties: {names: {type: 'array'}}}});
+      var c = new Collection('persons', {db: db.create(TEST_DB), config: { properties: {names: {type: 'array'}}}});
 
       c.save({body: {names: ['jim','sam']}}, function (err, item) {
         expect(item.id).to.exist;
@@ -218,7 +218,7 @@ describe('collection', function(){
     });
 
     it('should not add duplicate element on $addUnique', function(done) {
-      var c = new Collection('counts', {db: db.create(TEST_DB), config: { properties: {names: {type: 'array'}}}});
+      var c = new Collection('persons', {db: db.create(TEST_DB), config: { properties: {names: {type: 'array'}}}});
 
       c.save({body: {names: ['jim','sam', 'joe']}}, function (err, item) {
         expect(item.id).to.exist;
@@ -227,6 +227,21 @@ describe('collection', function(){
           expect(err).to.not.exist;
           expect(updated).to.exist;
           expect(updated.names).to.eql(['jim', 'sam', 'joe']);
+          done(err);
+        });
+      });
+    });
+
+    it('should not add duplicate elements and add unique elements on $addUnique', function(done) {
+      var c = new Collection('persons', {db: db.create(TEST_DB), config: { properties: {names: {type: 'array'}}}});
+
+      c.save({body: {names: ['jim','sam', 'joe']}}, function (err, item) {
+        expect(item.id).to.exist;
+        expect(err).to.not.exist;
+        c.save({body: {names: {$addUnique: ['carmen', 'jim', 'keith', 'paulus', 'sam', 'joe']}}, query: {id: item.id}}, function (err, updated) {
+          expect(err).to.not.exist;
+          expect(updated).to.exist;
+          expect(updated.names).to.eql(['jim', 'sam', 'joe', 'carmen', 'keith', 'paulus']);
           done(err);
         });
       });


### PR DESCRIPTION
Fixed #140
Opted for `$addUnique` because it is much simpler than `$addToSet`.
Below is an example usage:

```
{
  "persons": {
    "$addUnique": ["me", "you"]
  },
  "colors": {
    "$addUnique": "pink"
  }
}
```
