### PR TITLE
Fixes #254:  On put, if you protect() every field, will wipe out entire ...

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -509,14 +509,18 @@ Collection.prototype.save = function (ctx, fn) {
         }
 
         delete item.id;
-        store.update({id: query.id}, item, function (err) {
-          if(err) return done(err);
-          item.id = id;
+        if (Object.keys(item).length === 0) {
+            done(new Error("Not authorized."));
+        } else {
+            store.update({id: query.id}, item, function (err) {
+                if(err) return done(err);
+                item.id = id;
 
-          done(null, item);
+                done(null, item);
 
-          if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
-        });
+                if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
+            });
+        }  
       }
 
       if (collection.shouldRunEvent(collection.events.Validate, ctx)) {


### PR DESCRIPTION
This will fix the collection getting wiped out.  Skips the update to the store if the object contains now valid keys. (i.e. fields in a collection)
