### PR TITLE
fix(dashboard): add check for undefined config

### DIFF
--- a/lib/resources/dashboard.js
+++ b/lib/resources/dashboard.js
@@ -16,7 +16,7 @@ function Dashboard() {
 
   this.loadTypes = async.memoize(this.loadTypes);
   this.loadLayout = async.memoize(this.loadLayout);
-  
+
   Resource.apply(this, arguments);
 }
 util.inherits(Dashboard, Resource);
@@ -34,9 +34,9 @@ Dashboard.prototype.handle = function(ctx, next) {
   } else if (ctx.url.indexOf('/__custom') === 0) {
     this.serveCustomAsset(ctx, next);
   } else if (ctx.url.indexOf('.') !== -1) {
-    filed(path.join(__dirname, 'dashboard', ctx.url)).pipe(ctx.res);  
-  } else if (!ctx.req.isRoot && ctx.server.options.env !== 'development') {
-    filed(path.join(__dirname, 'dashboard', 'auth.html')).pipe(ctx.res);  
+    filed(path.join(__dirname, 'dashboard', ctx.url)).pipe(ctx.res);
+  } else if (!ctx.req.isRoot && (!ctx.server.options || ctx.server.options.env !== 'development')) {
+    filed(path.join(__dirname, 'dashboard', 'auth.html')).pipe(ctx.res);
   } else {
     this.render(ctx);
   }
@@ -61,7 +61,7 @@ Dashboard.prototype.serveCustomAsset = function(ctx, next) {
       resourceType = types[resourceTypeId];
       dashboardPath = resourceType && resourceType.dashboard && resourceType.dashboard.path;
       if (dashboardPath) {
-        return filed(path.join(dashboardPath, reqUrl)).pipe(ctx.res); 
+        return filed(path.join(dashboardPath, reqUrl)).pipe(ctx.res);
       }
     }
 
@@ -81,7 +81,7 @@ Dashboard.prototype.loadTypes = function(fn) {
 Dashboard.prototype.render = function(ctx) {
   var self = this
     , appName = path.basename(path.resolve('./'))
-    , env = ctx.server && ctx.server.options.env;
+    , env = ctx.server && ctx.server.options && ctx.server.options.env;
 
   async.parallel({
       layout: self.loadLayout
@@ -106,12 +106,12 @@ Dashboard.prototype.render = function(ctx) {
     render.bodyHtml = options.bodyHtml;
 
     try {
-      var rendered = results.layout({context: context, render: render, scripts: options.scripts || [], css: options.css || null});  
+      var rendered = results.layout({context: context, render: render, scripts: options.scripts || [], css: options.css || null});
       ctx.res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       ctx.res.end(rendered);
     } catch (ex) {
       ctx.done(ex.message);
-    }  
+    }
   });
 };
 
@@ -155,7 +155,7 @@ Dashboard.prototype.loadPage = function(ctx, fn) {
       }
       if (page === 'config') page = 'index';
 
-      dashboardPath = resourceType.dashboard && resourceType.dashboard.path; 
+      dashboardPath = resourceType.dashboard && resourceType.dashboard.path;
 
       async.waterfall([
         function(fn) {
@@ -163,7 +163,7 @@ Dashboard.prototype.loadPage = function(ctx, fn) {
             pagePath = path.join(dashboardPath, page + '.html');
             fs.exists(pagePath, function(exists) {
               fn(null, exists);
-            });  
+            });
           } else {
             fn(null, false);
           }


### PR DESCRIPTION
In dashboard.js, the dashboard would sometimes
not open when starting deployd because
of an undefined config object.
This fix adds a check in a few places to ensure
that the config exists before checking its properties.
