### PR TITLE
chore:(test) remove invalid require

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -6,9 +6,9 @@ var fs = require('fs')
 module.exports = function loadTypes(basepath, fn) {
   var types = {}
     , defaults = {};
-  
+
   if(typeof basepath == 'function') {
-    fn = basepath; 
+    fn = basepath;
     basepath = undefined;
   }
 
@@ -27,7 +27,8 @@ module.exports = function loadTypes(basepath, fn) {
     fs.readdir(path + '/node_modules', function(err, dir) {
       var remaining = 0;
       if(dir && dir.length) {
-        dir.forEach(function(file) {  
+        dir.forEach(function(file) {
+          if (file === 'grunt-contrib-jshint') return;
           if(file.indexOf('.js') == file.length - 3 || file.indexOf('.') === -1) {
             var d = domain.create();
             remaining++;
@@ -39,22 +40,22 @@ module.exports = function loadTypes(basepath, fn) {
                   var c = require(require('path').resolve(path) + '/node_modules/' + file);
                   if(c && c.prototype && c.prototype.__resource__) {
                     debug('is a resource ', c && c.name);
-                    types[c.name] = c; 
+                    types[c.name] = c;
                   }
-                } catch(e) { 
+                } catch(e) {
                   console.error();
                   console.error("Error loading module node_modules/" + file);
                   console.error(e.stack || e);
                   if(process.send) process.send({moduleError: e || true});
                   process.exit(1);
                 }
-              
+
                 if(remaining === 0) {
                   fn(defaults, types);
                 }
               });
             });
-          
+
             d.on('error', function (err) {
               console.error('Error in module node_modules/' + file);
               console.error(err.stack || err);


### PR DESCRIPTION
Change invalid attempt to require grunt-contrib-jshint so that tests can run.
Remove trailing whitespace from lib/type-loader.js.
