### PR TITLE
test(server): Correct sanitization test logic

### DIFF
--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -140,10 +140,10 @@ describe('Collection', function() {
     });
 
     describe('.post({title: "foo", owner: 7}, fn)', function() {
-      it('should sanitize the owner due to incorrect type', function(done) {
+      it('should coerce numbers to strings when querying string properties', function(done) {
         dpd.todos.post({title: "foo", owner: 7}, function (todo, err) {
           delete todo.id;
-          expect(todo).to.eql({title: "foo", done: false});
+          expect(todo).to.eql({title: "foo", done: false, owner: '7'});
           done();
         });
       });


### PR DESCRIPTION
This test used to read: "should sanitize the owner due to incorrect type," but
this is no longer how the query logic actually works. The query is currently
designed to coerce numeric arguments to strings when the underlying field being
queried on is a string, so this test (which used to ensure that the field
shouldn't be found) is no longer valid. Instead, I changed it to test that the
field is found despite the fact that it is queried for using a number instead
of a string.
