### PR TITLE
docs(readme) correct test-app instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Deployd is the simplest way to build realtime APIs for web and mobile apps. Read
 ## integration tests
 	
 	cd test-app
-	dpd -o
+	../bin/dpd -o
 
 ## license
 


### PR DESCRIPTION
Correct README.md so that it tells the user to run dpd from the right directory.
