### PR TITLE
Added remote address of client to script context

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -64,10 +64,12 @@ Script.prototype.run = function (ctx, domain, fn) {
         if(session.emitToAll) session.emitToAll(event, data);
       }
     },
-    remoteAddress: req.headers['x-forwarded-for'] ||
-      req.connection.remoteAddress ||
-      req.socket.remoteAddress ||
-      req.connection.socket.remoteAddress
+    remoteAddress: (!req || req.internal) ? undefined : (
+      req.headers && req.headers['x-forwarded-for'] ||
+      req.connection && req.connection.remoteAddress ||
+      req.socket && req.socket.remoteAddress ||
+      req.connection && req.connection.socket && req.connection.socket.remoteAddress 
+    )
   };
   
   scriptContext._this = scriptContext['this'];


### PR DESCRIPTION
If there is need to insert remote address of client or to use it for validation.
then it should be able to been retrieved on script context.
