### PR TITLE
Feature: Allow functions to be added to collection script domain

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -573,7 +573,7 @@ Collection.prototype.save = function (ctx, fn) {
 
 Collection.domainAdditions = {};
 
-Collection.prototype.addScriptDomainFunction = function(name, fn) {
+Collection.addScriptDomainFunction = function(name, fn) {
   Collection.domainAdditions[name] = fn;
 }
 

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -571,6 +571,12 @@ Collection.prototype.save = function (ctx, fn) {
   }
 };
 
+Collection.domainAdditions = {};
+
+Collection.prototype.addScriptDomainFunction = function(name, fn) {
+  Collection.domainAdditions[name] = fn;
+}
+
 function createDomain(data, errors) {
   var hasErrors = false;
   var domain = {
@@ -596,6 +602,7 @@ function createDomain(data, errors) {
     'this': data,
     data: data
   };
+  util._extend(domain, Collection.domainAdditions);
   return domain;
 }
 

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -575,7 +575,7 @@ Collection.domainAdditions = {};
 
 Collection.addScriptDomainFunction = function(name, fn) {
   Collection.domainAdditions[name] = fn;
-}
+};
 
 function createDomain(data, errors) {
   var hasErrors = false;
@@ -604,7 +604,7 @@ function createDomain(data, errors) {
   };
   util._extend(domain, Collection.domainAdditions);
   return domain;
-};
+}
 
 Collection.defaultPath = '/my-objects';
 

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -604,7 +604,7 @@ function createDomain(data, errors) {
   };
   util._extend(domain, Collection.domainAdditions);
   return domain;
-}
+};
 
 Collection.defaultPath = '/my-objects';
 


### PR DESCRIPTION
Often one does repetitive things in the script domain, e.g. create a unique validator that one wishes to reuse, or a simple function that needs to be done on almost all collections, so this commit allows the users of deployd create generic functions they can inject into the script domain.