### PR TITLE
UserCollection: make password-hashing monkey-patch-able

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -5,7 +5,6 @@ var validation = require('validation')
   , EventEmitter = require('events').EventEmitter
   , uuid = require('../util/uuid')
   , crypto = require('crypto')
-  , SALT_LEN = 256
   , debug = require('debug')('user-collection');
 
 /**
@@ -39,6 +38,7 @@ util.inherits(UserCollection, Collection);
 
 UserCollection.dashboard = Collection.dashboard;
 UserCollection.events    = Collection.events;
+UserCollection.SALT_LEN = 256;
 
 /**
  * Handle an incoming http `req` and `res` and execute
@@ -105,10 +105,7 @@ UserCollection.prototype.handle = function (ctx) {
           if(err) return ctx.done(err);
 
           if(user) {
-            var salt = user.password.substr(0, SALT_LEN)
-              , hash = user.password.substr(SALT_LEN);
-
-            if(hash === uc.hash(credentials.password, salt)) {
+            if(uc.checkHash(uc, user, credentials) === true) {
               debug('logged in as %s', credentials.username);
               ctx.session.set({path: path, uid: user.id}).save(ctx.done);
               return;
@@ -123,8 +120,7 @@ UserCollection.prototype.handle = function (ctx) {
       /* falls through */
     case 'PUT':
       if(ctx.body && ctx.body.password) {
-        var salt = uuid.create(SALT_LEN);
-        ctx.body.password = salt + this.hash(ctx.body.password, salt);
+        this.setPassword(ctx.body);
       }
       var isSelf = ctx.session.user && ctx.session.user.id === ctx.query.id || (ctx.body && ctx.body.id);
       if ((ctx.query.id || ctx.body.id) && ctx.body && !isSelf && !ctx.session.isRoot && !ctx.req.internal) {
@@ -168,8 +164,20 @@ UserCollection.prototype.handleSession = function (ctx, fn) {
   }
 };
 
+UserCollection.prototype.setPassword = function (body) {
+  var salt = uuid.create(UserCollection.SALT_LEN);
+  body.password = salt + this.hash(body.password, salt);
+};
+
 UserCollection.prototype.hash = function (password, salt) {
   return crypto.createHmac('sha256', salt).update(password).digest('hex');
+};
+
+UserCollection.prototype.checkHash = function (uc, user, credentials) {
+  var salt = user.password.substr(0, UserCollection.SALT_LEN)
+    , hash = user.password.substr(UserCollection.SALT_LEN);
+
+  return hash === uc.hash(credentials.password, salt);
 };
 
 UserCollection.label = 'Users Collection';


### PR DESCRIPTION
This PR moves all hashing-code in [`UserCollection`](https://github.com/deployd/deployd/blob/master/lib/resources/user-collection.js) to the new functions `UC.prototype.setPassword` and `UC.prototype.checkHash`. This makes it possible to monkey-patch these functions inside a module. With this change a module can change the way passwords are hashed and verified, so migrating a existing user-database (which most likely uses a different algorithm) is possible.
