### PR TITLE
fix(session): correct usages of an emit queue.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -131,8 +131,8 @@ function Session(data, store, sockets, rawSockets) {
       if(s) {
         s.emit.apply(s, arguments);
       } else {
-        // otherwise add to bind queue
-        var queue = this._emitQueue = this._bindQueue || [];
+        // otherwise add to emit queue
+        var queue = this._emitQueue = this._emitQueue || [];
         queue.push(arguments);
       }
     }


### PR DESCRIPTION
In my opinion, it's just a typo.
