### PR TITLE
fix(type-loader) `Cannot load module` error

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -42,11 +42,14 @@ module.exports = function loadTypes(basepath, fn) {
                     types[c.name] = c;
                   }
                 } catch(e) {
-                  console.error();
-                  console.error("Error loading module node_modules/" + file);
-                  console.error(e.stack || e);
-                  if(process.send) process.send({moduleError: e || true});
-                  process.exit(1);
+                  // ignore errors from modules with incorrect main property in their package.json
+                  if (e && e.code !== 'MODULE_NOT_FOUND') {
+                    console.error();
+                    console.error("Error loading module node_modules/" + file);
+                    console.error(e.stack || e);
+                    if(process.send) process.send({moduleError: e || true});
+                    process.exit(1);
+                  }
                 }
 
                 if(remaining === 0) {


### PR DESCRIPTION
Ignoring errors from modules with incorrect main propery in their package.json and missed index.js

How to reproduce:

```
archer@captain ~/tmp $ mkdir yo-dpd
archer@captain ~/tmp $ cd yo-dpd/
archer@captain ~/tmp/yo-dpd $ yo deployd
archer@captain ~/tmp/yo-dpd $ npm install grunt-autoprefixer
archer@captain ~/tmp/yo-dpd $ dpd -d
starting deployd v0.7.0...

Error loading module node_modules/grunt-autoprefixer
Error: Cannot find module '/home/archer/tmp/yo-dpd/node_modules/grunt-autoprefixer'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /home/archer/dev/deployd/lib/type-loader.js:39:27
    at process._tickDomainCallback (node.js:463:13)
archer@captain ~/tmp/yo-dpd $ 
```

closed #381 
