### PR TITLE
feat(config-loader server): customize server and public dirs through options

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -150,9 +150,9 @@ function loadResourceExtras(resource, fn) {
 function addInternalResources(server, basepath, resources, fn) {
   var publicFolderQ = Q.fcall(function() {
     var defaultFolder = './public';
-
-    if (server.options && typeof server.options.env === 'string') {
-      var altPublic = './public-' + server.options.env;  
+    if (server.options) {
+      defaultFolder = server.options.public_dir || defaultFolder;
+      var altPublic = defaultFolder + '-' + server.options.env;
       var altPublicExistsQ = Q.defer();
       fs.exists(altPublic, function(exists) {
         altPublicExistsQ.resolve(exists);

--- a/lib/server.js
+++ b/lib/server.js
@@ -140,8 +140,9 @@ Server.prototype.handleRequest = function handleRequest (req, res) {
 
 Server.prototype.listen = function(port, host) {
   var server = this;
+  var serverpath = server.options.server_dir || './';
 
-  config.loadConfig('./', server, function(err, resourcesInstances) {
+  config.loadConfig(serverpath, server, function(err, resourcesInstances) {
     if (err) {
       console.error();
       console.error("Error loading resources: ");
@@ -159,8 +160,9 @@ Server.prototype.listen = function(port, host) {
 
 Server.prototype.route = function route (req, res) {
   var server = this;
+  var serverpath = server.options.server_dir || './';
 
-  config.loadConfig('./', server, function(err, resourcesInstances) {
+  config.loadConfig(serverpath, server, function(err, resourcesInstances) {
     if (err) throw err;
     var router = new Router(resourcesInstances, server);
     server.router = router;

--- a/test/config-loader.unit.js
+++ b/test/config-loader.unit.js
@@ -89,5 +89,42 @@ describe('config-loader', function() {
         done();
       });
     });
+
+    it('should use public_dir option if available', function(done) {
+      sh.mkdir('-p', path.join(basepath, 'resources'));
+      configLoader.loadConfig(basepath, {}, function(err, resourceList) {
+          if (err) return done(err);
+          expect(resourceList[0].config.public).to.equal('./public');
+      });
+
+      var opts = {};
+      opts.options = {};
+      opts.options.public_dir = 'test';
+
+      configLoader.loadConfig(basepath, opts, function(err, resourceList) {
+          if (err) return done(err);
+          expect(resourceList[0].config.public).to.equal('test');
+      });
+      done();
+    });
+
+    it('should use env options path if exists', function(done) {
+      sh.mkdir('-p', path.join(basepath, 'resources'));
+
+      var public_dir = basepath + '/test';
+
+      var opts = {};
+      opts.options = {};
+      opts.options.public_dir = public_dir;
+      opts.options.env = 'dev';
+
+      sh.mkdir('-p', public_dir + '-dev');
+
+      configLoader.loadConfig(basepath, opts, function(err, resourceList) {
+          if (err) return done(err);
+          expect(resourceList[0].config.public).to.equal(public_dir + '-dev');
+          done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR allows setting the `server` and `public` folder from server options using the `server_dir` and `public_dir` properties respectively.
I'm not sure how this will play with external modules. 
I can also add documentation to this PR if this might be merged at some point.
