### PR TITLE
Chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,32 +24,30 @@
     "http-proxy": "0.8.1",
     "mkdirp": "*",
     "mongodb": "1.0.2",
-    "opener": "~1.3.0",
+    "opener": "~1.4.0",
     "q": "~0.8.9",
-    "qs": "~1.2.1",
+    "qs": "~2.3.3",
     "request": "2.x.x",
     "scrubber": "*",
-    "semver": "1.1.x",
+    "semver": "~4.1.0",
     "send": "0.0.2",
     "shelljs": "https://github.com/dallonf/shelljs/tarball/master",
     "socket.io": "0.9.x",
     "step": ">=0.0.5",
-    "tar": "0.1.x",
     "underscore": "1.x.x",
     "validation": "*",
     "wrench": "1.3.x"
   },
   "devDependencies": {
     "chai": "*",
-    "dox": "*",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "^0.1.1",
-    "grunt-contrib-less": "~0.5.2",
+    "grunt-contrib-less": "~0.12.0",
     "less": "*",
     "mocha": "*",
     "node-markdown": "*",
     "rewire": "~2.0.0",
-    "sinon": "~1.7.3"
+    "sinon": "~1.12.1"
   },
   "bin": {
     "dpd": "./bin/dpd"


### PR DESCRIPTION
- sinon -> 1.12.1 unit & integration test pass
- dox: removed unit & integration test pass
- semver: -> 4.1.0: unit & integration test pass
- qs -> 2.3.3: unit & integration test pass
- opener -> 1.4.0: unit & integration test pass
- tar removed: unit & integration test pass
- grunt-contrib-less -> 0.12.0: unit & integration test pass
