### PR TITLE
Revert "chore: bump version to 0.7.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ritchie Martori",
   "name": "deployd",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "description": "the simplest way to build realtime APIs for web and mobile apps",
   "repository": {
     "url": "git://github.com/deployd/deployd.git"


### PR DESCRIPTION
Reverts deployd/deployd#430
Current state contains more than minor changes.
Instead of a 0.7.1, let's create a release candidate for 0.8.0.
