### PR TITLE
style(db): improve error messages when mongod is not available

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -127,8 +127,7 @@ function getConnection(db, fn) {
         console.error('Cannot connect to mongodb!');
         debug('mongodb options:', db.options);
         debug(err);
-        process.exit(1);
-        //throw err;
+        throw err;
       } else {
         // check for credentials
         var credentials = db.options.credentials;
@@ -140,8 +139,7 @@ function getConnection(db, fn) {
               console.error('Mongodb authenticate fail!');
               debug('mongodb options:', db.options);
               debug(err);
-              process.exit(1);
-              //throw err;
+              throw err;
             }
             db.connected = true;
             fn(null, db._mdb);


### PR DESCRIPTION
Example:

```
Cannot connect to mongodb { host: 'localhost', port: 27017, name: 'db_name' }
```
