### PR TITLE
fix(internal-client): exec resource.path is missing

### DIFF
--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -200,7 +200,7 @@ function createResourceClient(resource, baseMethods) {
 
     fn = arguments[i];
 
-    settings.path = joinPath(resource, settings.func, settings.path);
+    settings.path = joinPath(resource.path, settings.func, settings.path);
     return baseMethods.post(settings, fn);
   };
 


### PR DESCRIPTION
Missing ".path" compare to get/post/put/del functions
