### PR TITLE
feat(events): Expose ctx object to the event scripts

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -63,7 +63,8 @@ Script.prototype.run = function (ctx, domain, fn) {
         data = query;
         if(session.emitToAll) session.emitToAll(event, data);
       }
-    }
+    },
+    ctx: ctx
   };
   
   scriptContext._this = scriptContext['this'];


### PR DESCRIPTION
Following [this discussion](https://github.com/deployd/deployd/pull/304), this PR will expose the whole `ctx` object to the event API.
The `ctx` object contains many useful stuff like:
- request
- query / headers
- body
- response
- session
- etc...

Once this is validated, I will  add some documentation about this on this page:
http://docs.deployd.com/docs/collections/reference/event-api.html#s-console.log()-764

Usage example in the ON GET Event:

```
if (ctx && ctx.req && ctx.req.headers && ctx.req.headers.host !== '192.168.178.34:2403') {
    cancel("You are not authorized to do that", 401);
}
```
