### PR TITLE
Added no-cache headers to all responses

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -56,11 +56,6 @@ UserCollection.prototype.handle = function (ctx) {
     return Collection.prototype.handle.apply(uc, arguments);
   }
 
-  // set no-cache headers
-  ctx.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate")
-  ctx.res.setHeader("Pragma", "no-cache")
-  ctx.res.setHeader("Expires", "0")
-
   if(ctx.url === '/logout') {
     if (ctx.res.cookies) ctx.res.cookies.set('sid', null);
     ctx.session.remove(ctx.done);
@@ -88,6 +83,10 @@ UserCollection.prototype.handle = function (ctx) {
       if(ctx.url === '/me') {
         debug('session %j', ctx.session.data);
         if(!(ctx.session && ctx.session.data && ctx.session.data.uid)) {
+          // set no-cache headers
+          ctx.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+          ctx.res.setHeader("Pragma", "no-cache");
+          ctx.res.setHeader("Expires", "0");
           ctx.res.statusCode = 204;
           return ctx.done();
         }


### PR DESCRIPTION
(This relates to https://github.com/deployd/deployd/issues/202)

User-collection now sets the following headers to all responses: 

Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache,
Expires: 0

According to http://stackoverflow.com/questions/49547/ these are the correct headers to set to disable caching in most browsers.
