### PR TITLE
correctly delete cookies, update cookies-dependency

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -57,7 +57,7 @@ UserCollection.prototype.handle = function (ctx) {
   }
 
   if(ctx.url === '/logout') {
-    if (ctx.res.cookies) ctx.res.cookies.set('sid', null);
+    if (ctx.res.cookies) ctx.res.cookies.set('sid', null, {overwrite: true});
     ctx.session.remove(ctx.done);
     return;
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "async": "0.1.x",
     "commander": "^2.2.0",
-    "cookies": "^0.3.0",
+    "cookies": "^0.4.0",
     "corser": "^2.0.0",
     "debug": "^2.1.0",
     "doh": "^0.0.4",


### PR DESCRIPTION
fixed a bug that would cause a logout call to be handled incorrectly. instead of removing the session-cookie altogether, only another cookie (with the same name `sid`) was set leading to undefined behavior.

This requires an updated version of the cookies-library, as overwrite can only be specified in 0.4.x and defaulted to `false` before.