### PR TITLE
Fix: Allow changed() function to work properly with collection properties of type object

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -448,7 +448,7 @@ Collection.prototype.save = function (ctx, fn) {
 
   domain.changed =  function (property) {
     if(domain.data.hasOwnProperty(property)) {
-      if(domain.previous && domain.previous[property] === domain.data[property]) {
+      if(domain.previous && _.isEqual(domain.previous[property], domain.data[property])) {
         return false;
       }
 

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -1090,6 +1090,25 @@ describe('Collection', function() {
       });
     });
 
+    it('should not return true when a value of type object has not changed', function(done) {
+      dpd.changed.post({name: 'irrelevant', data: { 'key': '$NO_CHANGE'} }, function (c) {
+        dpd.changed.put(c.id, { data: { 'key': '$NO_CHANGE'} }, function (c) {
+          expect(c.data.changed).to.not.exist;
+          done();
+        });
+      });
+    });
+
+    it('should detect when a value of type object has changed', function(done) {
+      dpd.changed.post({name: 'irrelevant', data: { 'key': '$NO_CHANGE'} }, function (c) {
+        dpd.changed.put(c.id, { data: { 'key': '$CHANGED'} }, function (c) {
+          expect(c.data.key).to.equal("$CHANGED");
+          expect(c.data.changed).to.be.true;
+          done();
+        });
+      });
+    });
+
     afterEach(function (done) {
       this.timeout(10000);
       cleanCollection(dpd.changed, done);

--- a/test-app/resources/changed/config.json
+++ b/test-app/resources/changed/config.json
@@ -8,6 +8,14 @@
 			"required": false,
 			"id": "name",
 			"order": 0
+		},
+		"data": {
+			"name": "data",
+			"type": "object",
+			"typeLabel": "object",
+			"required": false,
+			"id": "data",
+			"order": 1
 		}
 	}
 }

--- a/test-app/resources/changed/put.js
+++ b/test-app/resources/changed/put.js
@@ -3,3 +3,7 @@ if(this.name === '$NO_CHANGE') {
         this.name = 'saw name change';
     }
 }
+
+if (changed('data')) {
+    this.data.changed = true;
+}


### PR DESCRIPTION
changed('prop') in event scripts would return true even if the object was not changed. This fixes it by using underscore's deep object comparison functionality.