### PR TITLE
Fix(config-loader): Memory leak and inefficiency

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -20,8 +20,6 @@ var fs = require('fs')
 module.exports.loadConfig = function(basepath, server, fn) {
   var resources = server.__resourceCache || [];
 
-  server.__resourceCache = null;
-
   if (resources.length) {
     debug("Loading from cache");
     fn(null, resources);


### PR DESCRIPTION
Every second HTTP request would reload the entire resources dir resulting in potential memory leaks.