### PR TITLE
feat(core): wait for promises in events

### DIFF
--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -1,5 +1,5 @@
-var debug = require('debug')('internal-client'),
-    bluebird = require('bluebird');
+var debug = require('debug')('internal-client')
+  , bluebird = require('bluebird');
 
 function normalizeArray(parts, allowAboveRoot) {
   // if the path tries to go above the root, `up` ends up > 0
@@ -84,9 +84,8 @@ exports.build = function(server, session, stack) {
       var callback = function(data, error) {
         if (typeof fn === 'function') {
           // call our callback
-          deferred.promise.then(function () {
-            fn(data, error);
-          }, function () {
+          deferred.promise
+          .done(function () {
             fn(data, error);
           });
         }

--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -1,4 +1,5 @@
-var debug = require('debug')('internal-client');
+var debug = require('debug')('internal-client'),
+    ayepromise = require('../clib/ayepromise');
 
 function normalizeArray(parts, allowAboveRoot) {
   // if the path tries to go above the root, `up` ends up > 0
@@ -65,7 +66,8 @@ exports.build = function(server, session, stack) {
         , res
         , urlKey
         , recursions
-        , recursionLimit;
+        , recursionLimit
+        , deferred = ayepromise.defer();
 
       req = {
           url: joinPath('/', options.path)
@@ -77,6 +79,23 @@ exports.build = function(server, session, stack) {
         , internal: true
         , headers: {}
         , on: function() {}
+      };
+
+      var callback = function(data, error) {
+        if (typeof fn === 'function') {
+          // call our callback
+          deferred.promise.then(function () {
+            fn(data, error);
+          }, function () {
+            fn(data, error);
+          });
+        }
+        // resolve or reject promise
+        if (error) {
+          deferred.reject(error);
+        } else {
+          deferred.resolve(data);
+        }
       };
 
       urlKey = req.method + ' ' + req.url;
@@ -95,16 +114,14 @@ exports.build = function(server, session, stack) {
         res = {
           setHeader: function() {},
           end: function(data) {
-            if (typeof fn === 'function') {
-              if (res.statusCode === 200 || res.statusCode === 204) {
-                try {
-                  fn(JSON.parse(data), null);
-                } catch (ex) {
-                  fn(data, null);
-                }
-              } else {
-                fn(null, data);
+            if (res.statusCode === 200 || res.statusCode === 204) {
+              try {
+                callback(JSON.parse(data), null);
+              } catch (ex) {
+                callback(data, null);
               }
+            } else {
+              callback(null, data);
             }
           },
           internal: true,
@@ -115,8 +132,10 @@ exports.build = function(server, session, stack) {
         server.router.route(req, res);
       } else {
         debug("Recursive call detected - aborting");
-        if (typeof fn === 'function') fn(null, "Recursive call to " + urlKey + " detected");
+        callback(null, "Recursive call to " + urlKey + " detected");
       }
+
+      return deferred.promise;
     }
   };
 

--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -1,5 +1,5 @@
 var debug = require('debug')('internal-client'),
-    ayepromise = require('../clib/ayepromise');
+    bluebird = require('bluebird');
 
 function normalizeArray(parts, allowAboveRoot) {
   // if the path tries to go above the root, `up` ends up > 0
@@ -67,7 +67,7 @@ exports.build = function(server, session, stack) {
         , urlKey
         , recursions
         , recursionLimit
-        , deferred = ayepromise.defer();
+        , deferred = bluebird.defer();
 
       req = {
           url: joinPath('/', options.path)

--- a/lib/script.js
+++ b/lib/script.js
@@ -142,6 +142,117 @@ function wrapError(err) {
   return err;
 }
 
+function isPromise(obj) {
+  //maybe not the best of all checks but at least it's compliant to Promises/A+
+  //see https://promisesaplus.com
+  return typeof obj === 'object' && (typeof obj.then === 'function' || isPromise(obj.promise));
+}
+
+function wrapPromise(promiseable, sandbox, events, done, sandboxRoot) {
+  var realPromise = promiseable;
+  if(!promiseable.then && promiseable.promise && isPromise(promiseable.promise)) {
+    realPromise = promiseable.promise;
+  }
+
+  var _then = realPromise.then;
+  realPromise.then = function(onFulfilled, onRejected) {
+    events.emit('addCallback');
+
+    var args = [
+      // wrappedOnFulfilled
+      function(res) {
+        var result = onFulfilled.apply(sandboxRoot._this, arguments);
+        events.emit('finishCallback');
+
+        return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
+      }
+    ];
+
+    if(onRejected) {
+      args.push(
+        // wrappedOnRejected
+        function(err) {
+          var result = onRejected.apply(sandboxRoot._this, arguments);
+
+          events.emit('finishCallback');
+          return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
+        }
+      );
+    } else {
+      args.push(
+        function(err) {
+          events.emit('finishCallback');
+
+          // this is needed to pass the error along
+          // couldn't find official docs to prove this is the way to go, 
+          // but at least ayepromise and when.js require it that way to chain rejections (without relying on rejected promise)
+          throw (err instanceof Error) ? err : new Error(err);
+        }
+      );
+    }
+    var result = _then.apply(realPromise, args);
+    return isPromise(result)? wrapPromise(result, sandbox, events, done, sandboxRoot) : result;
+  };
+
+  return promiseable;
+}
+
+function wrapAsyncFunction(asyncFunction, sandbox, events, done, sandboxRoot) {
+  return function() {
+    if (sandboxRoot._error) return;
+
+    var args = _.toArray(arguments);
+    var callback;
+    var callbackIndex;
+    var result;
+    
+    for(var i = 0; i < args.length; i++) {
+      if(typeof args[i] == 'function') {
+        callback = args[i];
+        callbackIndex = i;
+        break;
+      }
+    }
+
+
+    
+    if (typeof callback === 'function') {
+      events.emit('addCallback');
+      args[callbackIndex] = function() {
+        if (sandboxRoot._error) return;
+        try {
+          result = callback.apply(sandboxRoot._this, arguments);
+          events.emit('finishCallback');
+        } catch (err) {
+          var wrappedErr = wrapError(err);
+          sandbox._error = wrappedErr;
+          return done(wrappedErr);
+        }
+      };
+    } else {
+      args.push(function() {
+        if (sandboxRoot._error) return;
+        events.emit('finishCallback');
+      });
+    }
+    try {
+      result = asyncFunction.apply(sandboxRoot._this, args);
+    } catch(err) {
+      var wrappedErr = wrapError(err);
+      sandbox._error = wrappedErr;
+      return done(wrappedErr);
+    }
+    
+    if(result !== undefined) {
+      if(isPromise(result)) {
+        return wrapPromise(result, sandbox, events, done, sandboxRoot);
+      } else {
+        return result;
+      }
+    }
+  };
+}
+
 function wrapAsyncFunctions(asyncFunctions, sandbox, events, done, sandboxRoot) {
   if (!sandboxRoot) sandboxRoot = sandbox;
 
@@ -152,53 +263,10 @@ function wrapAsyncFunctions(asyncFunctions, sandbox, events, done, sandboxRoot) 
 
   Object.keys(asyncFunctions).forEach(function(k) {
     if (typeof asyncFunctions[k] === 'function') {
-      sandbox[k] = function() {
-        if (sandboxRoot._error) return;
+      sandbox[k] = wrapAsyncFunction(asyncFunctions[k], sandbox, events, done, sandboxRoot);
 
-        var args = _.toArray(arguments);
-        var callback;
-        var callbackIndex;
-        var result;
-        
-        for(var i = 0; i < args.length; i++) {
-          if(typeof args[i] == 'function') {
-            callback = args[i];
-            callbackIndex = i;
-            break;
-          }
-        }
-        
-        if (typeof callback === 'function') {
-          events.emit('addCallback');
-          args[callbackIndex] = function() {
-            if (sandboxRoot._error) return;
-            try {
-              result = callback.apply(sandboxRoot._this, arguments);
-              events.emit('finishCallback');
-            } catch (err) {
-              var wrappedErr = wrapError(err);
-              sandbox._error = wrappedErr;
-              return done(wrappedErr);
-            }
-          };
-        } else {
-          args.push(function() {
-            if (sandboxRoot._error) return;
-            events.emit('finishCallback');
-          });
-        }
-        try {
-          result = asyncFunctions[k].apply(sandboxRoot._this, args);
-        } catch(err) {
-          var wrappedErr = wrapError(err);
-          sandbox._error = wrappedErr;
-          return done(wrappedErr);
-        }
-        
-        if(result !== undefined) {
-          return result;
-        }
-      };
+      // we need to retain all the properties a function might have, think constructor with static functions
+      wrapAsyncFunctions(asyncFunctions[k], sandbox[k], events, done, sandboxRoot);
     } else if (typeof asyncFunctions[k] === 'object' && !(asyncFunctions[k] instanceof Array)) {
       sandbox[k] = sandbox[k] || {};
       wrapAsyncFunctions(asyncFunctions[k], sandbox[k], events, done, sandboxRoot);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "index",
   "dependencies": {
     "async": "^0.9.0",
+    "bluebird": "^2.9.3",
     "commander": "^2.2.0",
     "cookies": "^0.4.0",
     "corser": "^2.0.0",

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -953,6 +953,32 @@ describe('Collection', function() {
 
   });
 
+  describe('internal client', function () {
+    before(function(done) {
+      cleanCollection(dpd.internalclientmaster, done);
+    });
+    it("should work properly with normal callbacks and promises", function (done) {
+      var masterId;
+      var children = [];
+      dpd.internalclientmaster.post({ title: "hello" }).then(function (data) {
+        masterId = data.id;
+        return dpd.internalclientdetail.post({ masterId: masterId, data: "data 1" });
+      }).then(function (data) {
+        children.push(data);
+        return dpd.internalclientdetail.post({ masterId: masterId, data: "data 2" });
+      }).then(function (data) {
+        children.push(data);
+        return dpd.internalclientmaster.get(masterId).then(function (master) {
+          expect(master.children).to.eql(children);
+          expect(master.childrenPromise).to.eql(children);
+          done();
+        });
+      }).fail(function (err) {
+        done(err);
+      });
+    });
+  });
+
   describe('dpd.recursive', function() {
     beforeEach(function(done) {
       dpd.recursive.post({name: "dataception"}, function(res) {

--- a/test-app/resources/internal-client-detail/config.json
+++ b/test-app/resources/internal-client-detail/config.json
@@ -1,0 +1,21 @@
+{
+    "type": "Collection",
+    "properties": {
+        "masterId": {
+            "name": "masterId",
+            "type": "string",
+            "typeLabel": "string",
+            "required": true,
+            "id": "masterId",
+            "order": 0
+        },
+        "data": {
+            "name": "data",
+            "type": "string",
+            "typeLabel": "string",
+            "required": true,
+            "id": "data",
+            "order": 1
+        }
+    }
+}

--- a/test-app/resources/internal-client-master/config.json
+++ b/test-app/resources/internal-client-master/config.json
@@ -1,0 +1,13 @@
+{
+    "type": "Collection",
+    "properties": {
+        "title": {
+            "name": "title",
+            "type": "string",
+            "typeLabel": "string",
+            "required": true,
+            "id": "title",
+            "order": 0
+        }
+    }
+}

--- a/test-app/resources/internal-client-master/get.js
+++ b/test-app/resources/internal-client-master/get.js
@@ -1,0 +1,8 @@
+dpd.internalclientdetail.get({masterId: this.id}).then(function (data) {
+    this.childrenPromise = data;
+}.bind(this));
+
+
+dpd.internalclientdetail.get({masterId: this.id}, function(data, err) {
+    this.children = data;
+}.bind(this));

--- a/test/script.unit.js
+++ b/test/script.unit.js
@@ -1,4 +1,5 @@
 var Script = require('../lib/script');
+    ayepromise = require('../clib/ayepromise');
 
 describe('script', function(){
   describe('.run(ctx, fn)', function(done){
@@ -78,6 +79,92 @@ describe('script', function(){
       });
       
       
+    });
+  });
+
+  describe('promises', function(){
+    it('should resolve after promise is resolved', function(done) {
+      this.timeout(200);
+      var s = new Script('var p = aye.defer(); p.promise.then(inc); setTimeout(p.resolve, 10)');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+      
+      s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
+    });
+
+    it('should reject after promise is rejected', function(done) {
+      this.timeout(200);
+      var s = new Script('var p = aye.defer(); p.promise.then(function() {}, inc); setTimeout(p.reject, 10)');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+      
+      s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
+    });
+
+    it('should resolve after nested promises is resolved and outer promise is resolved', function(done) {
+      this.timeout(200);
+      var s = new Script('var p = aye.defer(), p2 = aye.defer(); p.promise.then(function() { return p2.promise; }).then(inc); setTimeout(p.resolve, 22); setTimeout(p2.resolve, 44);');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+      
+      s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
+    });
+
+    it('should reject after nested promises is rejected and outer promise is resolved', function(done) {
+      this.timeout(200);
+      var s = new Script('var p = aye.defer(), p2 = aye.defer(); p.promise.then(function() { return p2.promise; }).then(function() {}, inc); setTimeout(p.resolve, 22); setTimeout(p2.reject, 44);');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+      
+      s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
+    });
+
+    it('should reject after nested promises is resolved and outer promise is rejected', function(done) {
+      this.timeout(200);
+      var s = new Script('var p = aye.defer(), p2 = aye.defer(); p.promise.then(function() { return p2.promise; }).then(function() {}, inc); setTimeout(p.reject, 22); setTimeout(p2.resolve, 44);');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+      
+      s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
+    });
+
+    it('should reject after nested promises is rejected and outer promise is rejected', function(done) {
+      this.timeout(200);
+      var s = new Script('var p = aye.defer(), p2 = aye.defer(); p.promise.then(function() { return p2.promise; }).then(function() {}, inc); setTimeout(p.reject, 22); setTimeout(p2.reject, 44);');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+      
+      s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
With these changes you can safely use promises in events, because they are now wrapped just like async functions before. This allows for way cleaner code in event handlers.

Also, this change fixes a minor issue where the function `wrapAsyncFunctions` would silently discard every property of the wrapped function. This leads to problems when you put constructors inside a domain that is wrapped (i.e. only the constructor function was retained, static properties and methods were discarded).