### PR TITLE
fix(dpd.js): parse script src for root url, apposed to window.location

### DIFF
--- a/clib/dpd.js
+++ b/clib/dpd.js
@@ -2,10 +2,7 @@
 
   if (!window._dpd) window._dpd = {};
 
-  var root = window.location.protocol + '//' + window.location.hostname;
-  if (window.location.port !== '') {
-    root += ':' + window.location.port;
-  }
+  var root = document.currentScript.getAttribute('src').replace(/\/dpd\.js$/, '');
 
   var consoleLog = (typeof console !== 'undefined') && console.log;
 

--- a/clib/dpd.js
+++ b/clib/dpd.js
@@ -21,6 +21,7 @@
       for (var i = 0; i < scriptTags.length; i++) {
         if (scriptTags[i].hasAttribute('src') && scriptTags[i].getAttribute('src').match(/.*dpd\.js$/)) {
           element = scriptTags[i];
+          break;
         }
       }
     }

--- a/clib/dpd.js
+++ b/clib/dpd.js
@@ -2,18 +2,30 @@
 
   if (!window._dpd) window._dpd = {};
 
-  var root = window.location.protocol + '//' + window.location.hostname;
-  if (window.location.port !== '') {
-    root += ':' + window.location.port;
-  }
+  var root = currentScript().getAttribute('src')
+      .replace(/(.*)(\/.*\.js)$/, '$1')
+      .replace(/^[^\/]*.js$/, '');
 
-  var scriptTags = document.getElementsByTagName('script');
-  for (var i = 0; i < scriptTags.length; i++) {
-    var src = scriptTags[i].getAttribute('src');
-    if (src !== null && src.match(/.*\/dpd\.js$/)) {
-      root = src.replace(/\/dpd\.js$/, '');
-      break;
+  function currentScript() {
+    // Only works in modern non-IE browsers
+    var currentScript = document.currentScript;
+
+    if (!currentScript) {
+      // Allows script to have a name other than dpd.js by assigning id="dpd.js" to script tag
+      currentScript = document.getElementById('dpd.js');
     }
+
+    if (!currentScript || !currentScript.hasAttribute('src')) {
+      // As a last resort, loop through all script tags and find the src attribute ending in "dpd.js"
+      var scriptTags = document.getElementsByTagName('script');
+      for (var i = 0; i < scriptTags.length; i++) {
+        if (scriptTags[i].hasAttribute('src') && scriptTags[i].getAttribute('src').match(/.*dpd\.js$/)) {
+          currentScript = scriptTags[i];
+        }
+      }
+    }
+
+    return currentScript;
   }
 
   var consoleLog = (typeof console !== 'undefined') && console.log;

--- a/clib/dpd.js
+++ b/clib/dpd.js
@@ -2,30 +2,30 @@
 
   if (!window._dpd) window._dpd = {};
 
-  var root = currentScript().getAttribute('src')
+  var root = dpdScriptElement().getAttribute('src')
       .replace(/(.*)(\/.*\.js)$/, '$1')
       .replace(/^[^\/]*.js$/, '');
 
-  function currentScript() {
+  function dpdScriptElement() {
     // Only works in modern non-IE browsers
-    var currentScript = document.currentScript;
+    var element = document.currentScript;
 
-    if (!currentScript) {
+    if (!element) {
       // Allows script to have a name other than dpd.js by assigning id="dpd.js" to script tag
-      currentScript = document.getElementById('dpd.js');
+      element = document.getElementById('dpd.js');
     }
 
-    if (!currentScript || !currentScript.hasAttribute('src')) {
+    if (!element || !element.hasAttribute('src')) {
       // As a last resort, loop through all script tags and find the src attribute ending in "dpd.js"
       var scriptTags = document.getElementsByTagName('script');
       for (var i = 0; i < scriptTags.length; i++) {
         if (scriptTags[i].hasAttribute('src') && scriptTags[i].getAttribute('src').match(/.*dpd\.js$/)) {
-          currentScript = scriptTags[i];
+          element = scriptTags[i];
         }
       }
     }
 
-    return currentScript;
+    return element;
   }
 
   var consoleLog = (typeof console !== 'undefined') && console.log;

--- a/clib/dpd.js
+++ b/clib/dpd.js
@@ -2,7 +2,19 @@
 
   if (!window._dpd) window._dpd = {};
 
-  var root = document.currentScript.getAttribute('src').replace(/\/dpd\.js$/, '');
+  var root = window.location.protocol + '//' + window.location.hostname;
+  if (window.location.port !== '') {
+    root += ':' + window.location.port;
+  }
+
+  var scriptTags = document.getElementsByTagName('script');
+  for (var i = 0; i < scriptTags.length; i++) {
+    var src = scriptTags[i].getAttribute('src');
+    if (src !== null && src.match(/.*\/dpd\.js$/)) {
+      root = src.replace(/\/dpd\.js$/, '');
+      break;
+    }
+  }
 
   var consoleLog = (typeof console !== 'undefined') && console.log;
 


### PR DESCRIPTION

enable users to host deployd on a subdomain (e.g. api.mydomain.com) and still use dpd.js

might resolve #83 & #149, see https://groups.google.com/forum/#!topic/deployd-users/CT84hulBO40