### PR TITLE
fix(db): update/delete should return count of records affected

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -449,9 +449,9 @@ Store.prototype.update = function (query, object, fn) {
   debug('update - command', command);
 
   collection(this, function (err, col) {
-      col.update(query, command, {multi: multi}, function(err) {
+    col.update(query, command, { multi: multi }, function (err, r) {
       store.identify(query);
-      fn(err);
+      fn(err, r ? { n: r.result.n } : null);
     }, multi);
   });
 };
@@ -481,8 +481,7 @@ Store.prototype.remove = function (query, fn) {
     store.identify(query);
   }
   collection(this, function (err, col) {
-    // newer mongodb client returns a non null result on successful deletion
-    col.remove(query, function (error, result) { fn(error); });
+    col.remove(query, function (error, r) { fn(error, r ? { n: r.result.n } : null); });
   });
 };
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -451,7 +451,7 @@ Store.prototype.update = function (query, object, fn) {
   collection(this, function (err, col) {
     col.update(query, command, { multi: multi }, function (err, r) {
       store.identify(query);
-      fn(err, r ? { n: r.result.n } : null);
+      fn(err, r ? { count: r.result.n } : null);
     }, multi);
   });
 };
@@ -481,7 +481,7 @@ Store.prototype.remove = function (query, fn) {
     store.identify(query);
   }
   collection(this, function (err, col) {
-    col.remove(query, function (error, r) { fn(error, r ? { n: r.result.n } : null); });
+    col.remove(query, function (error, r) { fn(error, r ? { count: r.result.n } : null); });
   });
 };
 

--- a/test-app/public/test/user-collection.test.js
+++ b/test-app/public/test/user-collection.test.js
@@ -230,7 +230,9 @@ describe('User Collection', function() {
 			it('should remove a user', function(done) {
 				dpd.users.post(credentials, function (user, err) {
 					expect(user.id.length).to.equal(16);
-					dpd.users.del({id: user.id}, function (session, err) {
+					dpd.users.del({id: user.id}, function (res, err) {
+						expect(err).to.not.exist;
+						expect(res.n).to.equal(1);
 						dpd.users.get({id: user.id}, function (user) {
 							expect(user).to.not.exist;
 							done(err);

--- a/test-app/public/test/user-collection.test.js
+++ b/test-app/public/test/user-collection.test.js
@@ -232,7 +232,7 @@ describe('User Collection', function() {
 					expect(user.id.length).to.equal(16);
 					dpd.users.del({id: user.id}, function (res, err) {
 						expect(err).to.not.exist;
-						expect(res.n).to.equal(1);
+						expect(res.count).to.equal(1);
 						dpd.users.get({id: user.id}, function (user) {
 							expect(user).to.not.exist;
 							done(err);

--- a/test/db.unit.js
+++ b/test/db.unit.js
@@ -100,7 +100,7 @@ describe('store', function(){
     it('should remove all the objects that match the query', function(done) {
       store.insert([{i:1},{i:2},{i:3}], function () {
         store.remove({i: {$lt: 3}}, function (err, result) {
-          expect(result.n).to.equal(2);
+          expect(result.count).to.equal(2);
           store.find(function (err, result) {
             expect(result).to.have.length(1);
             done(err);
@@ -112,7 +112,7 @@ describe('store', function(){
     it('should remove all the objects', function(done) {
       store.insert([{i:1},{i:2},{i:3}], function () {
         store.remove(function (err, result) {
-          expect(result.n).to.equal(3);
+          expect(result.count).to.equal(3);
           store.find(function (err, result) {
             expect(result).to.eql([]);
             done(err);
@@ -151,7 +151,7 @@ describe('store', function(){
         var query = {id: result.id};
         store.update(query, {foo: 'baz'}, function (err, updated) {
           expect(err).to.not.exist;
-          expect(updated.n).to.equal(1);
+          expect(updated.count).to.equal(1);
           store.first(query, function (err, result) {
             expect(result.foo).to.equal('baz');
             done(err);
@@ -165,7 +165,7 @@ describe('store', function(){
         if(err) throw err;
         store.update({}, {$rename: {foo: 'RENAMED'}}, function (err, updated) {
           if(err) throw err;
-          expect(updated.n).to.equal(3);
+          expect(updated.count).to.equal(3);
           store.find(function (err, all) {
             all.forEach(function (item) {
               expect(item.RENAMED).to.exist;

--- a/test/db.unit.js
+++ b/test/db.unit.js
@@ -100,7 +100,7 @@ describe('store', function(){
     it('should remove all the objects that match the query', function(done) {
       store.insert([{i:1},{i:2},{i:3}], function () {
         store.remove({i: {$lt: 3}}, function (err, result) {
-          expect(result).to.not.exist;
+          expect(result.n).to.equal(2);
           store.find(function (err, result) {
             expect(result).to.have.length(1);
             done(err);
@@ -112,7 +112,7 @@ describe('store', function(){
     it('should remove all the objects', function(done) {
       store.insert([{i:1},{i:2},{i:3}], function () {
         store.remove(function (err, result) {
-          expect(result).to.not.exist;
+          expect(result.n).to.equal(3);
           store.find(function (err, result) {
             expect(result).to.eql([]);
             done(err);
@@ -149,8 +149,9 @@ describe('store', function(){
       store.insert({foo: 'bar'}, function (err, result) {
         expect(err).to.not.exist;
         var query = {id: result.id};
-        store.update(query, {foo: 'baz'}, function (err) {
+        store.update(query, {foo: 'baz'}, function (err, updated) {
           expect(err).to.not.exist;
+          expect(updated.n).to.equal(1);
           store.first(query, function (err, result) {
             expect(result.foo).to.equal('baz');
             done(err);
@@ -162,8 +163,9 @@ describe('store', function(){
     it('should rename all objects', function(done) {
       store.insert([{foo: 'bar'}, {foo: 'bat'}, {foo: 'baz'}], function (err) {
         if(err) throw err;
-        store.update({}, {$rename: {foo: 'RENAMED'}}, function (err) {
+        store.update({}, {$rename: {foo: 'RENAMED'}}, function (err, updated) {
           if(err) throw err;
+          expect(updated.n).to.equal(3);
           store.find(function (err, all) {
             all.forEach(function (item) {
               expect(item.RENAMED).to.exist;


### PR DESCRIPTION
This is specified in the documentation here:
http://docs.deployd.com/docs/developing-modules/internal-api/store.html#s-Store.update%28query,%20changes,%20fn%29-1117
But wasn't working.

It will fix https://github.com/deployd/deployd/issues/492