### PR TITLE
fix(collection): call Delete event for every record matched

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -383,7 +383,7 @@ Collection.prototype.remove = function (ctx, fn) {
     
     // nothing to delete
     if (result.length === 0) {
-      return fn(null, { n: 0 });
+      return fn(null, { count: 0 });
     }
       
     var remaining = result.length

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -375,21 +375,50 @@ Collection.prototype.remove = function (ctx, fn) {
     if(err) {
       return fn(err);
     }
+    
+    // convert result to an array if it is not
+    if (!Array.isArray(result)) {
+      result = [result];
+    }
+    
+    // nothing to delete
+    if (result.length === 0) {
+      return fn(null, { n: 0 });
+    }
+      
+    var remaining = result.length
+      , idsToDelete = [];
+      
+    function done(id, err) {
+      remaining--;
+      if (result.length === 1 && err) {
+        // we only have one row to delete but an error has occured, pass it through
+        return fn(err);
+      }
+      
+      if (err && err instanceof Error) {
+        // only halt execution if an actual error was thrown from the script
+        // cancel() from within the script is not an instance of Error, so it will be ignored by this
+        return fn(err);
+      } else if (!err) {
+        // script executed without an error, this id will be deleted
+        idsToDelete.push(id);
+      }
 
-    function done(err) {
-      if(err) return fn(err);
-      store.remove(sanitizedQuery, fn);
-      if(session.emitToAll) session.emitToAll(collection.name + ':changed');
+      if(!remaining) {
+        store.remove({ id: { $in: idsToDelete } }, fn);
+        if (session.emitToAll) session.emitToAll(collection.name + ':changed');
+      }
     }
 
-    if(collection.shouldRunEvent(collection.events.Delete, ctx)) {
-      var domain = createDomain(result, errors);
-
-      domain['this'] = domain.data = result;
-      collection.events.Delete.run(ctx, domain, done);
-    } else {
-      done();
-    }
+    result.forEach(function(data) {
+      if (collection.shouldRunEvent(collection.events.Delete, ctx)) {
+        var domain = createDomain(data, errors);
+        collection.events.Delete.run(ctx, domain, function (err) { done(data.id, err);  });
+      } else {
+        done(data.id);
+      }
+    });
   });
 };
 

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -1,5 +1,56 @@
 /*global _dpd:false, $:false */
-describe('Collection', function() {
+describe('Collection', function () {
+  describe('dpd.delete', function () {
+    before(function (done) {
+      cleanCollection(dpd.delete, done);
+    });
+    it('should call delete event for every record when query matches more than one', function (done) {
+      var calls = 0;
+      dpd.socketReady(function () {
+        dpd.on('delete:called', function() {
+          calls++;
+          if (calls === 3) {
+            done();
+          }
+        });
+      });
+      dpd.delete.post({ data: '1' }).then(function() {
+        return dpd.delete.post({ data: '1' });
+      }).then(function() {
+        return dpd.delete.post({ data: '2' });
+      }).then(function() {
+        return dpd.delete.del({ id: { $ne: null } });
+      });
+    });
+      
+    it('should allow canceling deletion from script', function (done) {
+      dpd.delete.post({ data: '1' }).then(function() {
+        return dpd.delete.post({ data: '1' });
+      }).then(function() {
+        return dpd.delete.post({ data: '$DONTDELETE' });
+      }).then(function() {
+        return dpd.delete.del({ id: { $ne: null }, fromTest: true });
+      }).then(function() {
+        return dpd.delete.get();
+      }).then(function(result) {
+        expect(result.length).to.equal(1);
+        expect(result[0].data).to.equal('$DONTDELETE');
+        done();
+      }).fail(done);
+    });
+    
+    it('should return error if only one item to delete and an error occurs', function (done) {
+      dpd.delete.post({ data: '$DONTDELETE' }).then(function (d) {
+        return dpd.delete.del({ id: d.id, fromTest: true });
+      }).then(function() {
+        throw "An error should have been returned";
+      }, function (err) {
+        expect(err).to.exist;
+        expect(err.message).to.equal("Can't delete this one");
+        done();
+      });
+    });
+  });
   describe('dpd.todos', function() {
     it('should exist', function() {
       expect(dpd.todos).to.exist;

--- a/test-app/resources/delete/config.json
+++ b/test-app/resources/delete/config.json
@@ -1,0 +1,13 @@
+{
+	"type": "Collection",
+	"properties": {
+		"data": {
+			"name": "data",
+			"type": "string",
+			"typeLabel": "string",
+			"required": false,
+			"id": "data",
+			"order": 0
+		}
+	}
+}

--- a/test-app/resources/delete/delete.js
+++ b/test-app/resources/delete/delete.js
@@ -1,0 +1,3 @@
+emit('delete:called');
+
+if (ctx.query.fromTest && this.data === "$DONTDELETE") cancel("Can't delete this one");


### PR DESCRIPTION
You could actually pass a query to DELETE that matches more than one record, but the DELETE event was called just once for the whole operation.
This change correctly allows the event to occur several times, once for each record being matched, and allows canceling removal of certain records via `cancel()` from the event script;