### PR TITLE
No-cache headers on done()

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -92,6 +92,9 @@ Context.prototype.done = function(err, res) {
     }
 
     try {
+      this.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+      this.res.setHeader("Pragma", "no-cache");
+      this.res.setHeader("Expires", "0");
       if(status != 204 && status != 304) {
         if(body) {
           this.res.setHeader('Content-Length', Buffer.isBuffer(body)

--- a/lib/script.js
+++ b/lib/script.js
@@ -36,9 +36,6 @@ Script.prototype.run = function (ctx, domain, fn) {
   
   var scriptContext = {
     'this': {},
-    require: function(m){
-    	return require(m);
-    },
     cancel: function(msg, status) {
       var err = {message: msg, statusCode: status};
       throw err;

--- a/lib/script.js
+++ b/lib/script.js
@@ -36,6 +36,9 @@ Script.prototype.run = function (ctx, domain, fn) {
   
   var scriptContext = {
     'this': {},
+    require: function(m){
+    	return require(m);
+    },
     cancel: function(msg, status) {
       var err = {message: msg, statusCode: status};
       throw err;


### PR DESCRIPTION
Internet Explorer needs to see no-cache headers, otherwise it will cache the last API response and always return that (ignoring any changes). 

In the current master branch, no-cache headers are not set for PUT:s, which means if you update a collections multiple times (using PUT), IE wont recognize the changes. 

This patch adds no-cache headers to all API responses in the done() function of context.js, so that IE behaves nicely again... 