### PR TITLE
Enable require() in event scripts

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -92,6 +92,9 @@ Context.prototype.done = function(err, res) {
     }
 
     try {
+      this.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+      this.res.setHeader("Pragma", "no-cache");
+      this.res.setHeader("Expires", "0");
       if(status != 204 && status != 304) {
         if(body) {
           this.res.setHeader('Content-Length', Buffer.isBuffer(body)

--- a/lib/context.js
+++ b/lib/context.js
@@ -92,9 +92,6 @@ Context.prototype.done = function(err, res) {
     }
 
     try {
-      this.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-      this.res.setHeader("Pragma", "no-cache");
-      this.res.setHeader("Expires", "0");
       if(status != 204 && status != 304) {
         if(body) {
           this.res.setHeader('Content-Length', Buffer.isBuffer(body)

--- a/lib/script.js
+++ b/lib/script.js
@@ -36,9 +36,6 @@ Script.prototype.run = function (ctx, domain, fn) {
   
   var scriptContext = {
     'this': {},
-    require: function(m){
-    	return require(m);
-    },
     cancel: function(msg, status) {
       var err = {message: msg, statusCode: status};
       throw err;

--- a/lib/script.js
+++ b/lib/script.js
@@ -36,6 +36,9 @@ Script.prototype.run = function (ctx, domain, fn) {
   
   var scriptContext = {
     'this': {},
+    require: function(m){
+      return require(m);
+    },
     cancel: function(msg, status) {
       var err = {message: msg, statusCode: status};
       throw err;

--- a/lib/script.js
+++ b/lib/script.js
@@ -36,6 +36,9 @@ Script.prototype.run = function (ctx, domain, fn) {
   
   var scriptContext = {
     'this': {},
+    require: function(m){
+    	return require(m);
+    },
     cancel: function(msg, status) {
       var err = {message: msg, statusCode: status};
       throw err;


### PR DESCRIPTION
This patch enables require() in event scripts.

Please note that if you require() and run an asynchronous function in an event script, the event script might finish and return its value without waiting for your async function to complete.

(PS. Never mind the commit messages...)