### PR TITLE
feature(server): authenticate with Authorization: Bearer

### DIFF
--- a/lib/attach.js
+++ b/lib/attach.js
@@ -74,7 +74,7 @@ function attach(httpServer, options) {
   }
 
   // persist sessions in a store
-  var sessionStore = server.sessions = new SessionStore('sessions', server.db, server.sockets);
+  var sessionStore = server.sessions = new SessionStore('sessions', server.db, server.sockets, options.sessions);
 
   // persist keys in a store
   var keys = server.keys = new Keys();

--- a/lib/attach.js
+++ b/lib/attach.js
@@ -89,14 +89,28 @@ function attach(httpServer, options) {
     setupReqRes(req, res, function(err, next) {
       if(err) return res.end(err.message);
 
-      server.sessions.createSession(req.cookies.get('sid'), function(err, session) {
+      var authToken, usesBearerAuth = false;
+      if (req.headers && req.headers.authorization) {
+        var parts = req.headers.authorization.split(' ');
+        var scheme = parts[0]
+        , credentials = parts[1];
+        
+        if (/^Bearer$/i.test(scheme)) {
+          authToken = credentials;
+          usesBearerAuth = true;
+        }      
+      }
+      
+      server.sessions.createSession(authToken || req.cookies.get('sid'), function(err, session) {
 
         if(err) {
           debug('session error', err, session);
           throw err;
         } else {
-          // (re)set the session id
-          req.cookies.set('sid', session.sid);
+          if (!usesBearerAuth) {
+            // (re)set the session id cookie if we're not using Authorization Bearer
+            req.cookies.set('sid', session.sid);
+          }
           req.session = session;
 
           var root = req.headers['dpd-ssh-key'] || req.cookies.get('DpdSshKey');

--- a/lib/server.js
+++ b/lib/server.js
@@ -97,15 +97,28 @@ Server.prototype.handleRequest = function handleRequest (req, res) {
   // add utilites to req and res
   setupReqRes(req, res, function(err, next) {
     if(err) return res.end(err.message);
-
-    server.sessions.createSession(req.cookies.get('sid'), function(err, session) {
-
+    
+    var authToken, usesBearerAuth = false;
+    if (req.headers && req.headers.authorization) {
+      var parts = req.headers.authorization.split(' ');
+      var scheme = parts[0]
+      , credentials = parts[1];
+      
+      if (/^Bearer$/i.test(scheme)) {
+        authToken = credentials;
+        usesBearerAuth = true;
+      }      
+    }
+    
+    server.sessions.createSession(authToken || req.cookies.get('sid'), function(err, session) {
       if(err) {
         debug('session error', err, session);
         throw err;
       } else {
-        // (re)set the session id
-        req.cookies.set('sid', session.sid);
+        if (!usesBearerAuth) {
+          // (re)set the session id cookie if we're not using Authorization Bearer
+          req.cookies.set('sid', session.sid);
+        }
         req.session = session;
 
         var root = req.headers['dpd-ssh-key'] || req.cookies.get('DpdSshKey');

--- a/lib/server.js
+++ b/lib/server.js
@@ -72,7 +72,7 @@ function Server(options) {
   }).sockets;
 
   // persist sessions in a store
-  var sessionStore = this.sessions = new SessionStore('sessions', this.db, this.sockets);
+  var sessionStore = this.sessions = new SessionStore('sessions', this.db, this.sockets, options.sessions);
 
   // persist keys in a store
   var keys = this.keys = new Keys();
@@ -117,7 +117,7 @@ Server.prototype.handleRequest = function handleRequest (req, res) {
       } else {
         if (!usesBearerAuth) {
           // (re)set the session id cookie if we're not using Authorization Bearer
-          req.cookies.set('sid', session.sid);
+          if (session.sid) req.cookies.set('sid', session.sid);
         }
         req.session = session;
 

--- a/test-app/public/test/user-collection.test.js
+++ b/test-app/public/test/user-collection.test.js
@@ -210,6 +210,27 @@ describe('User Collection', function() {
           doLogin();
         });
       });
+      
+      it('should allow login with Authorization: Bearer HTTP header ', function (done) {
+        // ensure we're logged out
+        dpd.users.logout(function() {
+          // setting this header will disable setting a sid cookie by deployd
+          _dpd.ajax.headers = { Authorization: "Bearer" };
+          dpd.users.post({ username: 'authheader', password: '123456' }, function (user, err) {
+            expect(user.id.length).to.equal(16);
+            expect(user.lastLoginTime).to.not.exist;
+            dpd.users.login({ username: 'authheader', password: '123456' }).then(function (session) {
+              _dpd.ajax.headers = { Authorization: "Bearer " + session.id };
+              dpd.users.me(function (me, err) {
+                _dpd.ajax.headers = null;
+                expect(me).to.exist;
+                expect(me.username).to.equal("authheader");
+                done();
+              });
+            });
+          });
+        });
+      });
     });
 	    
 		describe('.me(fn)', function() {


### PR DESCRIPTION
Allow authentication using Authorization: Bearer HTTP header instead of cookies. This is especially useful when deployd is used cross domain because cookies are often unreliable.