### PR TITLE
fix(server): allow request.rawBody for middlewares

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -67,8 +67,30 @@ exports.setup = function(req, res, next) {
   });
 };
 
+
 /*!
- * Attempts to parse the stream. Currently supports the following formats:
+ * Gets the body the request by either reading a stream or by loading req.rawBody
+ * For compatibility with middlewares that read the stream, create compatibility
+ * middleware that writes to req.rawBody or override this method
+ * @param {ServerRequest} req
+ * @param {Function} callback (body)
+ */
+exports.getBody = function(req, callback){
+  if(req.rawBody) {
+    return callback(req.rawBody);
+  }
+
+  var buf = '';
+
+  req.on('data', function(chunk){ buf += chunk; });
+  
+  req.on('end', function(){
+    return callback(buf);
+  });
+};
+
+/*!
+ * Attempts to parse the request. Currently supports the following formats:
  *
  * - application/json
  * - application/x-www-form-urlencoded (all values are strings)
@@ -79,10 +101,8 @@ exports.setup = function(req, res, next) {
  */
 
 var parseBody = exports.parseBody = function(req, res, mime, callback) {
-  var buf = '';
-
-  req.on('data', function(chunk){ buf += chunk; });
-  req.on('end', function(){
+  exports.getBody(req, function(buf){
+    
     var parser = JSON;
 
     if (mime === 'application/x-www-form-urlencoded') {

--- a/test/util.unit.js
+++ b/test/util.unit.js
@@ -29,6 +29,53 @@ describe('http', function() {
 		});
 	});
 
+describe('.getBody', function(){
+
+  it('should get body from stream', function(done){
+
+    var obj = JSON.stringify({foo: 'bar'})
+      , req = new Stream();
+
+    var res = this.res;
+
+    http.getBody(req, function(buffer) {
+      console.error('STREAM', buffer, typeof buffer);
+      expect(buffer).to.exist;
+      expect(buffer).to.eql(obj);
+      done();
+    });
+
+    req.emit('data', obj);
+    req.emit('end');
+
+  });
+
+  it('should get body from rawBody', function(done){
+
+    var obj = JSON.stringify({foo: 'bar'})
+      , req = new Stream();
+
+    req.rawBody = '';
+    req.on('data', function(chunk){
+      req.rawBody += chunk;
+    })
+
+    var res = this.res;
+
+    req.on('end', function(){
+      http.getBody(req, function(buffer) {
+        expect(buffer).to.exist;
+        expect(buffer).to.eql(obj);
+        done();
+      });
+    });
+
+    req.emit('data', obj);
+    req.emit('end');
+
+  });
+
+});
 
 describe('.parseBody()', function() {
   beforeEach(function () {


### PR DESCRIPTION
Adds compatibility for middlewares that drained the request stream, e.g. body-parser.
Fixes #519