### PR TITLE
fix(internal-resource): handle errors in type events

### DIFF
--- a/lib/resources/internal-resources.js
+++ b/lib/resources/internal-resources.js
@@ -150,7 +150,9 @@ InternalResources.prototype.handle = function(ctx, next) {
         var newId = value.id;
         delete value.id;
         if (typeof value === 'object') value = JSON.stringify(value, null, '\t');
-        notifyType(id, 'Changed', resource, ctx.server, function() {
+        notifyType(id, 'Changed', resource, ctx.server, function(eventError) {
+          if(eventError) return ctx.done(eventError);
+
           fs.writeFile(file, value, function(err) {
             if (err) return ctx.done(err);
 
@@ -257,8 +259,8 @@ InternalResources.prototype.handle = function(ctx, next) {
       var resourcePath = path.join(basepath, 'resources', id);
       wrench.rmdirRecursive(resourcePath, function(err) {
         if (err) return ctx.done(err);
-        notifyType(id, 'Deleted', null, ctx.server, function() {
-          ctx.done();
+        notifyType(id, 'Deleted', null, ctx.server, function(eventError) {
+          ctx.done(eventError);
         });
       });
       break;

--- a/test/resources.unit.js
+++ b/test/resources.unit.js
@@ -193,5 +193,76 @@ describe('InternalResources', function() {
           throw Error("next called");
         });
     });
+
+    it('should call callbacks for config changes with errors', function(done) {
+      var file = path.join(configPath, 'resources/foo/config.json');
+
+      sh.mkdir('-p', path.join(configPath, 'resources/foo'));
+      JSON.stringify({type: 'Foo'}).to(file);
+
+      this.ir.handle(
+        {
+          server: {
+            resources: [
+              {
+                name: 'foo',
+                config: {},
+                configChanged: function(config, fn){
+                  console.log('CONFIG CHANGED!');
+                  return fn('ERROR');
+                }
+              }
+            ]
+          },
+          url: '/foo',
+          body: {type: 'Foo', value: {something: 'new config'}},
+          req: {
+            method: 'PUT', 
+            url: '/__resources/foo', 
+            isRoot: true
+          }, 
+          done: function(err){
+            console.log('CALL');
+            expect(err).to.exist.and.to.equal('ERROR');
+            done();
+          }
+      }
+    );
+
+
+    });
+    it('should call callbacks for resource deletion with errors', function(done) {
+      var file = path.join(configPath, 'resources/foo/config.json');
+
+      sh.mkdir('-p', path.join(configPath, 'resources/foo'));
+      JSON.stringify({type: 'Foo'}).to(file);
+
+      this.ir.handle(
+        {
+          server: {
+            resources: [
+              {
+                name: 'foo',
+                config: {},
+                configDeleted: function(config, fn){
+                  return fn('ERROR');
+                }
+              }
+            ]
+          },
+          url: '/foo',
+          body: {type: 'Foo', value: {something: 'new config'}},
+          req: {
+            method: 'DELETE', 
+            url: '/__resources/foo', 
+            isRoot: true
+          }, 
+          done: function(err){
+            expect(err).to.exist.and.to.equal('ERROR');
+            done();
+          }
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
The events used in lib/internal-resource previously ignored any errors that might have occured in the event, because it ignored the error argument in the callback, eventhough the callback might be called with one.
Allows resources to give back errors to the client when an invalid configuration happens.