### PR TITLE
Update Community Discussion Page link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The macosx installer is deprecated. The recommended way is now npm (`npm install
  - [Getting Started Guide](http://docs.deployd.com/docs/getting-started/what-is-deployd.html)
  - [Hello World Tutorial](http://docs.deployd.com/docs/getting-started/your-first-api.html)
  - [API Docs](http://docs.deployd.com/api)
- - [Community Discussion Page](http://deployd.com/community.html)
+ - [Community Discussion Page](https://groups.google.com/forum/?fromgroups#!forum/deployd-users)
  - [Example Apps](http://docs.deployd.com/examples/)
 
 ## install from npm

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The macosx installer is deprecated. The recommended way is now npm (`npm install
  - [Hello World Tutorial](http://docs.deployd.com/docs/getting-started/your-first-api.html)
  - [API Docs](http://docs.deployd.com/api)
  - [Community Discussion Page](https://groups.google.com/forum/?fromgroups#!forum/deployd-users)
+ - [Gitter Chat Page](https://gitter.im/deployd/deployd)
  - [Example Apps](http://docs.deployd.com/examples/)
 
 ## install from npm


### PR DESCRIPTION
The link to the Community Discussion Page in the Readme was returning a 404 error so I updated it to point to Deployd Users Google Group that the 'Community' link on the Deployd.com main page currently takes the end user to.