### PR TITLE
Feature: hide_dpdjs and hide_dashboard in config

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,22 +1,22 @@
 var fs = require('fs')
-  , path = require('path')
-  , _loadTypes = require('./type-loader')
-  , InternalResources = require('./resources/internal-resources')
-  , Files = require('./resources/files')
-  , ClientLib = require('./resources/client-lib')
-  , Dashboard = require('./resources/dashboard')
-  , debug = require('debug')('config-loader')
-  , domain = require('domain')
-  , async = require('async')
-  , Promise = require('bluebird');
+, path = require('path')
+, _loadTypes = require('./type-loader')
+, InternalResources = require('./resources/internal-resources')
+, Files = require('./resources/files')
+, ClientLib = require('./resources/client-lib')
+, Dashboard = require('./resources/dashboard')
+, debug = require('debug')('config-loader')
+, domain = require('domain')
+, async = require('async')
+, Promise = require('bluebird');
 
 /*!
- * Loads resources from a project folder
- * Callback receives two arguments `(err, resources)`.
- *
- * @param {String} basepath
- * @param {Function} callback
- */
+* Loads resources from a project folder
+* Callback receives two arguments `(err, resources)`.
+*
+* @param {String} basepath
+* @param {Function} callback
+*/
 module.exports.loadConfig = function(basepath, server, fn) {
   var resources = server.__resourceCache || [];
 
@@ -29,7 +29,7 @@ module.exports.loadConfig = function(basepath, server, fn) {
   var getTypes = async.memoize(loadTypes);
 
   async.waterfall([
-      async.apply(loadResourceDir, basepath)
+    async.apply(loadResourceDir, basepath)
     , async.apply(loadResources, getTypes, basepath, server)
     , async.apply(addInternalResources, server, basepath)
   ], function(err, result) {
@@ -94,14 +94,14 @@ function loadResources(getTypes, basepath, server, files, fn) {
       instance: ['configJson', 'types', function(fn, results) {
         debug("Loading resource: %s", resourceName);
         var config = results.configJson
-          , types = results.types
+        , types = results.types
 
-          , type = config.type
-          , resource
-          , o;
+        , type = config.type
+        , resource
+        , o;
 
         o = {
-            config: config
+          config: config
           , server: server
           , db: server.db
           , configPath: resourcePath
@@ -169,22 +169,27 @@ function addInternalResources(server, basepath, resources, fn) {
 
   publicFolderPromise.then(function(publicFolder) {
     var internals = [
-        new Files('', { config: { 'public': publicFolder }, server: server }),
-        new InternalResources('__resources', {config: {configPath: basepath}, server: server})
+      new Files('', { config: { 'public': publicFolder }, server: server }),
+      new InternalResources('__resources', {config: {configPath: basepath}, server: server})
     ];
-
-    if ( typeof server.options.hide_dpdjs !== 'undefined' && server.options.hide_dpdjs === true ) {
-      //hide dpd.js and dashboard
-      debug('Will not add (show) dpd.js and dashboard in internals array');
-    }else if ( typeof server.options.hide_dashboard !== 'undefined' && server.options.hide_dashboard === true ){
-      //hide dashboard
-      debug('Will not add (show) dashboard in internals array');
-      internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );
-    }else{
-      //show everything
-      debug('Will add (show) dpd.js and dashboard in internals array');
+    if( typeof server.options === 'undefined'){
+      debug('server.options is undefined. Will add (show) dpd.js and dashboard in internals array');
       internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );
       internals.push( new Dashboard('dashboard', {server: server}) );
+    }else{
+      if ( typeof server.options.hide_dpdjs !== 'undefined' && server.options.hide_dpdjs === true ) {
+        //hide dpd.js and dashboard
+        debug('Will not add (show) dpd.js and dashboard in internals array');
+      }else if ( typeof server.options.hide_dashboard !== 'undefined' && server.options.hide_dashboard === true ){
+        //hide dashboard
+        debug('Will not add (show) dashboard in internals array');
+        internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );
+      }else{
+        //show everything
+        debug('Will add (show) dpd.js and dashboard in internals array');
+        internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );
+        internals.push( new Dashboard('dashboard', {server: server}) );
+      }
     }
 
     async.forEach(internals, loadResourceExtras, function(err) {

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -173,10 +173,10 @@ function addInternalResources(server, basepath, resources, fn) {
         new InternalResources('__resources', {config: {configPath: basepath}, server: server})
     ];
 
-    if ( server.options.hide_dpdjs === true ) {
+    if ( typeof server.options.hide_dpdjs !== 'undefined' && server.options.hide_dpdjs === true ) {
       //hide dpd.js and dashboard
       debug('Will not add (show) dpd.js and dashboard in internals array');
-    }else if ( server.options.hide_dashboard === true ){
+    }else if ( typeof server.options.hide_dashboard !== 'undefined' && server.options.hide_dashboard === true ){
       //hide dashboard
       debug('Will not add (show) dashboard in internals array');
       internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -173,10 +173,10 @@ function addInternalResources(server, basepath, resources, fn) {
         new InternalResources('__resources', {config: {configPath: basepath}, server: server})
     ];
 
-    if ( server.options.hide_dpdjs ) {
+    if ( server.options.hide_dpdjs === true ) {
       //hide dpd.js and dashboard
       debug('Will not add (show) dpd.js and dashboard in internals array');
-    }else if ( server.options.hide_dashboard ){
+    }else if ( server.options.hide_dashboard === true ){
       //hide dashboard
       debug('Will not add (show) dashboard in internals array');
       internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,22 +1,22 @@
 var fs = require('fs')
-, path = require('path')
-, _loadTypes = require('./type-loader')
-, InternalResources = require('./resources/internal-resources')
-, Files = require('./resources/files')
-, ClientLib = require('./resources/client-lib')
-, Dashboard = require('./resources/dashboard')
-, debug = require('debug')('config-loader')
-, domain = require('domain')
-, async = require('async')
-, Promise = require('bluebird');
+  , path = require('path')
+  , _loadTypes = require('./type-loader')
+  , InternalResources = require('./resources/internal-resources')
+  , Files = require('./resources/files')
+  , ClientLib = require('./resources/client-lib')
+  , Dashboard = require('./resources/dashboard')
+  , debug = require('debug')('config-loader')
+  , domain = require('domain')
+  , async = require('async')
+  , Promise = require('bluebird');
 
 /*!
-* Loads resources from a project folder
-* Callback receives two arguments `(err, resources)`.
-*
-* @param {String} basepath
-* @param {Function} callback
-*/
+ * Loads resources from a project folder
+ * Callback receives two arguments `(err, resources)`.
+ *
+ * @param {String} basepath
+ * @param {Function} callback
+ */
 module.exports.loadConfig = function(basepath, server, fn) {
   var resources = server.__resourceCache || [];
 
@@ -29,7 +29,7 @@ module.exports.loadConfig = function(basepath, server, fn) {
   var getTypes = async.memoize(loadTypes);
 
   async.waterfall([
-    async.apply(loadResourceDir, basepath)
+      async.apply(loadResourceDir, basepath)
     , async.apply(loadResources, getTypes, basepath, server)
     , async.apply(addInternalResources, server, basepath)
   ], function(err, result) {
@@ -94,14 +94,14 @@ function loadResources(getTypes, basepath, server, files, fn) {
       instance: ['configJson', 'types', function(fn, results) {
         debug("Loading resource: %s", resourceName);
         var config = results.configJson
-        , types = results.types
+          , types = results.types
 
-        , type = config.type
-        , resource
-        , o;
+          , type = config.type
+          , resource
+          , o;
 
         o = {
-          config: config
+            config: config
           , server: server
           , db: server.db
           , configPath: resourcePath

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -13,7 +13,7 @@ var fs = require('fs')
 /*!
  * Loads resources from a project folder
  * Callback receives two arguments `(err, resources)`.
- * 
+ *
  * @param {String} basepath
  * @param {Function} callback
  */
@@ -70,7 +70,7 @@ function loadResourceDir(basepath, fn) {
 
 function loadResources(getTypes, basepath, server, files, fn) {
   async.map(files, function(resourceName, fn) {
-    var resourcePath = path.join(basepath, 'resources', resourceName); 
+    var resourcePath = path.join(basepath, 'resources', resourceName);
     var configPath = path.join(resourcePath, 'config.json');
     async.auto({
       types: function(fn) {
@@ -169,13 +169,26 @@ function addInternalResources(server, basepath, resources, fn) {
 
   publicFolderPromise.then(function(publicFolder) {
     var internals = [
-        new Files('', { config: { 'public': publicFolder }, server: server })
-      , new ClientLib('dpd.js', { config: { resources: resources }, server: server})
-      , new InternalResources('__resources', {config: {configPath: basepath}, server: server})
-      , new Dashboard('dashboard', {server: server})
+        new Files('', { config: { 'public': publicFolder }, server: server }),
+        new InternalResources('__resources', {config: {configPath: basepath}, server: server})
     ];
+
+    if ( server.options.hide_dpdjs ) {
+      //hide dpd.js and dashboard
+      debug('Will not add (show) dpd.js and dashboard in internals array');
+    }else if ( server.options.hide_dashboard ){
+      //hide dashboard
+      debug('Will not add (show) dashboard in internals array');
+      internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );
+    }else{
+      //show everything
+      debug('Will add (show) dpd.js and dashboard in internals array');
+      internals.push( new ClientLib('dpd.js', { config: { resources: resources }, server: server}) );
+      internals.push( new Dashboard('dashboard', {server: server}) );
+    }
+
     async.forEach(internals, loadResourceExtras, function(err) {
-      fn(err, resources.concat(internals));  
+      fn(err, resources.concat(internals));
     });
   });
 

--- a/test/config-loader.unit.js
+++ b/test/config-loader.unit.js
@@ -31,7 +31,7 @@ describe('config-loader', function() {
 
     it('should load resources', function(done) {
       this.timeout(10000);
-      
+
       sh.mkdir('-p', path.join(basepath, 'resources/foo'));
       sh.mkdir('-p', path.join(basepath, 'resources/bar'));
       JSON.stringify({type: "Collection", val: 1}).to(path.join(basepath, 'resources/foo/config.json'));
@@ -42,7 +42,7 @@ describe('config-loader', function() {
         expect(resources).to.have.length(6);
         expect(resources.filter(function(r) { return r.name == 'foo';})).to.have.length(1);
         expect(resources.filter(function(r) { return r.name == 'bar';})).to.have.length(1);
-        done();  
+        done();
       });
     });
 
@@ -68,11 +68,47 @@ describe('config-loader', function() {
         expect(resourceList).to.have.length(4);
 
         expect(resourceList[0] instanceof Files).to.equal(true);
-        expect(resourceList[1] instanceof ClientLib).to.equal(true);
-        expect(resourceList[2] instanceof InternalResources).to.equal(true);
-        expect(resourceList[3] instanceof Dashboard).to.equal(true);      
+        expect(resourceList[1] instanceof InternalResources).to.equal(true);
+        expect(resourceList[2] instanceof ClientLib).to.equal(true);
+        expect(resourceList[3] instanceof Dashboard).to.equal(true);
 
-        done(err);  
+        done(err);
+      });
+    });
+
+    it('should add internal resources but hide_dpdjs', function(done) {
+      sh.mkdir('-p', path.join(basepath, 'resources'));
+
+      server = { options: { hide_dpdjs: true } }
+
+      configLoader.loadConfig(server, basepath, {}, function(err, resourceList) {
+        if (err) return done(err);
+        expect(resourceList).to.have.length(4);
+
+        expect(resourceList[0] instanceof Files).to.equal(true);
+        expect(resourceList[1] instanceof InternalResources).to.equal(true);
+        expect(resourceList[2] instanceof ClientLib).to.equal(false);
+        expect(resourceList[3] instanceof Dashboard).to.equal(false);
+
+        done(err);
+      });
+    });
+
+    it('should add internal resources but hide_dashboard', function(done) {
+      sh.mkdir('-p', path.join(basepath, 'resources'));
+
+      server = { options: { hide_dashboard: true } }
+
+      configLoader.loadConfig(server, basepath, {}, function(err, resourceList) {
+        if (err) return done(err);
+        expect(resourceList).to.have.length(4);
+
+        expect(resourceList[0] instanceof Files).to.equal(true);
+        expect(resourceList[1] instanceof InternalResources).to.equal(true);
+        expect(resourceList[2] instanceof ClientLib).to.equal(true);
+        expect(resourceList[3] instanceof Dashboard).to.equal(false);
+
+        done(err);
       });
     });
 
@@ -132,8 +168,8 @@ describe('config-loader', function() {
           done();
       });
     });
-      
-    
+
+
     it('should read directories only once on multiple server.route requests', function (done) {
       sh.mkdir('-p', path.join(basepath, 'resources'));
       var server = new Server({ server_dir: basepath });
@@ -160,7 +196,7 @@ describe('config-loader', function() {
 
       var req = { url: 'foo', headers: {} };
       var res = { body: 'bar' };
-        
+
       var fs = require('fs');
       sinon.spy(fs, 'readdir');
 

--- a/test/config-loader.unit.js
+++ b/test/config-loader.unit.js
@@ -83,12 +83,10 @@ describe('config-loader', function() {
 
       configLoader.loadConfig( basepath, server, function(err, resourceList) {
         if (err) return done(err);
-        expect(resourceList).to.have.length(4);
+        expect(resourceList).to.have.length(2);
 
         expect(resourceList[0] instanceof Files).to.equal(true);
         expect(resourceList[1] instanceof InternalResources).to.equal(true);
-        expect(resourceList[2] instanceof ClientLib).to.equal(false);
-        expect(resourceList[3] instanceof Dashboard).to.equal(false);
 
         done(err);
       });
@@ -101,12 +99,11 @@ describe('config-loader', function() {
 
       configLoader.loadConfig( basepath, server, function(err, resourceList) {
         if (err) return done(err);
-        expect(resourceList).to.have.length(4);
+        expect(resourceList).to.have.length(3);
 
         expect(resourceList[0] instanceof Files).to.equal(true);
         expect(resourceList[1] instanceof InternalResources).to.equal(true);
         expect(resourceList[2] instanceof ClientLib).to.equal(true);
-        expect(resourceList[3] instanceof Dashboard).to.equal(false);
 
         done(err);
       });

--- a/test/config-loader.unit.js
+++ b/test/config-loader.unit.js
@@ -81,7 +81,7 @@ describe('config-loader', function() {
 
       server = { options: { hide_dpdjs: true } }
 
-      configLoader.loadConfig(server, basepath, {}, function(err, resourceList) {
+      configLoader.loadConfig( basepath, server, function(err, resourceList) {
         if (err) return done(err);
         expect(resourceList).to.have.length(4);
 
@@ -99,7 +99,7 @@ describe('config-loader', function() {
 
       server = { options: { hide_dashboard: true } }
 
-      configLoader.loadConfig(server, basepath, {}, function(err, resourceList) {
+      configLoader.loadConfig( basepath, server, function(err, resourceList) {
         if (err) return done(err);
         expect(resourceList).to.have.length(4);
 


### PR DESCRIPTION
Added new feature. You can now specify in config to hide /dashboard/ from public
or dpd.js file (and dashboard because it works based on dpd.js file)
from public.