### PR TITLE
bugfix: crashes if no password is defined on login

### DIFF
--- a/lib/modules/user-collection.js
+++ b/lib/modules/user-collection.js
@@ -100,7 +100,7 @@ UserCollection.prototype.handle = function (ctx) {
           this.store.first({username: credentials.username}, function(err, user) {
             if(err) return ctx.done(err);
 
-            if(user) {
+            if(user && credentials.password) {
               var salt = user.password.substr(0, SALT_LEN)
                 , hash = user.password.substr(SALT_LEN);
 


### PR DESCRIPTION
Deployd crashes when someone is sending a login request without specifying a "password" property.
This tiny change fixes this issue by checking if a password is defined at all before checking password validity.