### PR TITLE
feature(session): bind socket to session

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -44,6 +44,20 @@ function SessionStore(namespace, db, sockets, options) {
         socketIndex[sid] = socket;
         socketQueue.emit(sid, socket);
       }
+      
+      // Alternative way of binding session to socket connection
+      // for when the sid cookie is not yet available.
+      // This expects that the client emits an event with the sid.
+      socket.on('server:setSession', function(data) {
+        if (!data || !data.sid) { return; }
+        
+        var sid = data.sid;
+        var session = sessionIndex[sid]; 
+        if (session) {
+          socketIndex[sid] = socket;
+          socketQueue.emit(sid, socket);
+        }
+      });
     });
   } 
 
@@ -93,6 +107,7 @@ SessionStore.prototype.createSession = function(sid, fn) {
     fn = sid;
     sid = undefined;
   }
+
   if(sid) {
     this.find({ id: sid }, function (err, s) {
       if (err) return fn(err);
@@ -161,12 +176,13 @@ function Session(data, store, sockets, rawSockets) {
   if (!this.data.lastActive) this.data.lastActive = Date.now();
   if(data && data.id) this.sid = sid = data.id;
   this.store = store;
-
+  var self = this;
+  
   // create faux socket, to queue any events until
   // a real socket is available
   var socketWrapper = this.socket = {
     on: function () {
-      var s = sockets[sid];
+      var s = sockets[self.sid];
       // if we have a real socket, use it
       if(s) {
         s.on.apply(s, arguments);
@@ -177,8 +193,8 @@ function Session(data, store, sockets, rawSockets) {
       }
     },
     emit: function (ev) {
-      var s = sockets[sid];
-      
+      var s = sockets[self.sid];
+
       // if we have a real socket, use it
       if(s) {
         s.emit.apply(s, arguments);
@@ -202,7 +218,6 @@ function Session(data, store, sockets, rawSockets) {
       }
       users.forEach(function(u) {
         userSession = userSessionIndex[u.id];
-
         // emit to sessions online
         if(userSession && userSession.socket) {
           userSession.socket.emit(event, data);

--- a/test-app/resources/users/config.json
+++ b/test-app/resources/users/config.json
@@ -48,6 +48,14 @@
 			"required": false,
 			"id": "banned",
 			"order": 5
+		},
+		"admin": {
+			"name": "admin",
+			"type": "boolean",
+			"typeLabel": "boolean",
+			"required": false,
+			"id": "admin",
+			"order": 6
 		}
 	},
 	"typeLabel": "Users Collection",

--- a/test-app/resources/users/post.js
+++ b/test-app/resources/users/post.js
@@ -1,0 +1,2 @@
+emit(dpd.users, {admin:true}, 'users:created', {username: this.username} );
+//emit('users:created', this);

--- a/test-app/resources/users/post.js
+++ b/test-app/resources/users/post.js
@@ -1,2 +1,1 @@
 emit(dpd.users, {admin:true}, 'users:created', {username: this.username} );
-//emit('users:created', this);

--- a/test/sessions.unit.js
+++ b/test/sessions.unit.js
@@ -8,7 +8,8 @@ describe('SessionStore', function() {
 		var sockets = new EventEmitter()
 			,	store = new SessionStore('sessions', db.create(TEST_DB), sockets)
 			, fauxSocket = {
-					handshake: {headers: {cookie: 'name=value; name2=value2; sid=123'}}
+					handshake: {headers: {cookie: 'name=value; name2=value2; sid=123'}},
+					on: function() {}
 				};
 
 		sockets.emit('connection', fauxSocket);


### PR DESCRIPTION
This allows binding the socket to a session at a later time than the initial handshake when a sid cookie may not be available.

Example usage:
```javascript
dpd.users.login({ username: 'foo', password: 'bar'}).then(function(res) {
  dpd.socket.emit('server:setSession', { sid: res.id });
}
```

It should fix #533 