### PR TITLE
fix(user-collection): crash when password is not specified in login

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -162,6 +162,14 @@ UserCollection.prototype.handleLogin = function (ctx) {
     , credentials = ctx.req.body || {};
   
   debug('trying to login as %s', credentials.username);
+  /* jshint eqnull:true */
+  // disable the jshint warning about needing === below
+  // this checks whether the values are either null or undefined
+  if (credentials.username == null || credentials.password == null) {
+    ctx.res.statusCode = 400;
+    ctx.done('username or password not specified');
+    return;
+  }
   
   this.loginFindUser(ctx, function (err, user) {
     if (err) return ctx.done(err);

--- a/test-app/public/test/user-collection.test.js
+++ b/test-app/public/test/user-collection.test.js
@@ -77,7 +77,19 @@ describe('User Collection', function() {
           done();
         });
       });
-	  
+      
+      it('should not crash the server when called without a password', function(done) {
+        dpd.users.post({username: 'foo@bar.com', password: '123456'})
+        .then(function(res) {
+          expect(res).to.exist;
+          expect(res.username).to.equal('foo@bar.com');
+          dpd.users.login({username: 'foo@bar.com'}, function(session, err) {
+            expect(err).to.exist;
+            done();
+          });  
+        });
+      });
+      
       it('should call login event and provide access to user in event', function(done) {
         dpd.users.post(credentials, function (user, err) {
           expect(user.id.length).to.equal(16);


### PR DESCRIPTION
Added some further checks for returning an error when either the username or password is not specified on `login`.