### PR TITLE
Delete changed events.

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -407,7 +407,6 @@ Collection.prototype.remove = function (ctx, fn) {
 
       if(!remaining) {
         store.remove({ id: { $in: idsToDelete } }, fn);
-        if (session.emitToAll) session.emitToAll(collection.name + ':changed');
       }
     }
 
@@ -548,8 +547,6 @@ Collection.prototype.save = function (ctx, fn) {
           item.id = id;
 
           done(null, item);
-
-          if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
         });
       }
 
@@ -582,11 +579,9 @@ Collection.prototype.save = function (ctx, fn) {
         if(err || domain.hasErrors()) return done(err || errors);
         debug('inserting item', item);
         store.insert(item, done);
-        if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
       });
     } else {
       store.insert(item, done);
-      if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
     }
   }
 


### PR DESCRIPTION
To be able to use 'changed' events at our custom event filters.