### PR TITLE
feature(collection): add AfterCommit event

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -36,7 +36,7 @@ util.inherits(Collection, Resource);
 Collection.external = {};
 Collection.prototype.clientGeneration = true;
 
-Collection.events  = ['Get', 'Validate', 'Post', 'Put', 'Delete'];
+Collection.events  = ['Get', 'Validate', 'Post', 'Put', 'Delete', 'AfterCommit'];
 Collection.dashboard = {
     path: path.join(__dirname, 'dashboard')
   , pages: ['Properties', 'Data', 'Events', 'API']
@@ -389,7 +389,8 @@ Collection.prototype.remove = function (ctx, fn) {
     var remaining = result.length
       , idsToDelete = [];
       
-    function done(id, err) {
+    function done(data, err) {
+      var id = data.id;
       remaining--;
       if (result.length === 1 && err) {
         // we only have one row to delete but an error has occured, pass it through
@@ -406,17 +407,19 @@ Collection.prototype.remove = function (ctx, fn) {
       }
 
       if(!remaining) {
-        store.remove({ id: { $in: idsToDelete } }, fn);
-        if (session.emitToAll) session.emitToAll(collection.name + ':changed');
+        store.remove({ id: { $in: idsToDelete } }, function(){
+          collection.doAfterCommitEvent('DELETE', ctx, data);
+          fn.apply(null, arguments);
+        });
       }
     }
 
     result.forEach(function(data) {
       if (collection.shouldRunEvent(collection.events.Delete, ctx)) {
         var domain = createDomain(data, errors);
-        collection.events.Delete.run(ctx, domain, function (err) { done(data.id, err);  });
+        collection.events.Delete.run(ctx, domain, function (err) { done(data, err);  });
       } else {
-        done(data.id);
+        done(data);
       }
     });
   });
@@ -546,10 +549,8 @@ Collection.prototype.save = function (ctx, fn) {
         store.update({id: query.id}, item, function (err) {
           if(err) return done(err);
           item.id = id;
-
+          collection.doAfterCommitEvent('PUT', ctx, item);
           done(null, item);
-
-          if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
         });
       }
 
@@ -581,12 +582,12 @@ Collection.prototype.save = function (ctx, fn) {
         }
         if(err || domain.hasErrors()) return done(err || errors);
         debug('inserting item', item);
+        collection.doAfterCommitEvent('POST', ctx, item);
         store.insert(item, done);
-        if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
       });
     } else {
+      collection.doAfterCommitEvent('POST', ctx, item);
       store.insert(item, done);
-      if(session && session.emitToAll) session.emitToAll(collection.name + ':changed');
     }
   }
 
@@ -628,6 +629,15 @@ function createDomain(data, errors) {
     data: data
   };
   return domain;
+}
+
+Collection.prototype.doAfterCommitEvent = function(method, ctx, data){
+  var collection = this;
+  if (collection.shouldRunEvent(collection.events.AfterCommit, ctx)) {
+    collection.events.AfterCommit.run(ctx, {data: data, 'this': data, method: method}, function (err) { 
+      if (err) debug('AfterCommit errors in script: %j', err); 
+    });
+  }
 }
 
 Collection.defaultPath = '/my-objects';

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -643,7 +643,7 @@ Collection.prototype.doAfterCommitEvent = function(method, ctx, data){
       if (err) debug('AfterCommit errors in script: %j', err); 
     });
   }
-}
+};
 
 Collection.defaultPath = '/my-objects';
 

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -85,7 +85,7 @@ describe('Collection', function () {
     });
 
     describe('dpd.todos.on("changed", fn)', function() {
-      it('should respond to the built-in changed event on post', function(done) {
+      it('should respond to the changed event (in AfterCommit) on post', function(done) {
         dpd.socketReady(function() {
           dpd.todos.once('changed', function() {
             done();
@@ -95,7 +95,7 @@ describe('Collection', function () {
         });
       });
 
-      it('should respond to the built-in changed event on put', function(done) {
+      it('should respond to the changed event (in AfterCommit) on put', function(done) {
         dpd.todos.post({title: 'changed - create'}, function(item) {
           dpd.socketReady(function() {
             dpd.todos.once('changed', function() {
@@ -107,7 +107,7 @@ describe('Collection', function () {
         });
       });
 
-      it('should respond to the built-in changed event on del', function(done) {
+      it('should respond to the changed event (in AfterCommit) on del', function(done) {
         dpd.todos.post({title: 'changed - create'}, function(item) {
           dpd.socketReady(function() {
             dpd.todos.once('changed', function() {

--- a/test-app/public/test/user-collection.test.js
+++ b/test-app/public/test/user-collection.test.js
@@ -348,7 +348,7 @@ describe('User Collection', function() {
 			});
 		});
 		describe('dpd.users.on("changed", fn)', function() {
-      it('should respond to the built-in changed event on post', function(done) {
+      it('should respond to the changed event (in AfterCommit) on post', function(done) {
         dpd.socketReady(function() {
           dpd.users.once('changed', function() {
             done();
@@ -358,7 +358,7 @@ describe('User Collection', function() {
         });
       });
       
-      it('should respond to the built-in changed event on put', function(done) {
+      it('should respond to the changed event (in AfterCommit) on put', function(done) {
         dpd.users.post({username: 'foo2@bar.com', password: '123456'}, function(item) {
           dpd.socketReady(function() {
             dpd.users.once('changed', function() {
@@ -370,7 +370,7 @@ describe('User Collection', function() {
         });
       });
       
-      it('should respond to the built-in changed event on del', function(done) {
+      it('should respond to the changed event (in AfterCommit) on del', function(done) {
         dpd.users.post({username: 'foo2@bar.com', password: '123456'}, function(item) {
           dpd.socketReady(function() {
             dpd.users.once('changed', function() {

--- a/test-app/resources/todos/aftercommit.js
+++ b/test-app/resources/todos/aftercommit.js
@@ -1,0 +1,1 @@
+emit('todos:changed');

--- a/test-app/resources/users/aftercommit.js
+++ b/test-app/resources/users/aftercommit.js
@@ -1,0 +1,1 @@
+emit('users:changed');


### PR DESCRIPTION
Added AfterCommit event that is executed after changes are committed to the database. The domain contains a `method` (POST/PUT/DELETE) property and allows access to the newly committed data using `this` or `data`.

Removed built in 'collectionname:changed' socket.io event on collection change.

You may now emit this manually from the AfterCommit event by simply running `emit('colname:changed')` from within it.