### PR TITLE
fix(store): add error handling in callbacks

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -259,6 +259,10 @@ Store.prototype.insert = function (object, fn) {
   var store = this;
   this.identify(object);
   collection(this, function (err, col) {
+    if (err) {
+      fn(err);
+      return;
+    }
     col.insert(object, function (err, result) {
       if (err) {
         fn(err);
@@ -339,14 +343,26 @@ Store.prototype.find = function (query, fn) {
   if (!_.isObject(fields)) fields = undefined;
     
   collection(this, function (err, col) {
+    if (err) {
+      fn(err);
+      return;
+    }
     if(typeof query._id === 'string') {
       if(fields) {
         col.findOne(query, fields, options, function (err, obj) {
+          if (err) {
+            fn(err);
+            return;
+          }
           store.identify(query);
           fn(err, store.identify(obj));
         });
       } else {
         col.findOne(query, options, function (err, obj) {
+          if (err) {
+            fn(err);
+            return;
+          }
           store.identify(query);
           fn(err, store.identify(obj));
         });
@@ -354,10 +370,18 @@ Store.prototype.find = function (query, fn) {
     } else {
       if(fields) {
         col.find(query,  fields, options).toArray(function (err, arr) {
+          if (err) {
+            fn(err);
+            return;
+          }
           fn(err, store.identify(arr));
         });
       } else {
         col.find(query, options).toArray(function (err, arr) {
+          if (err) {
+            fn(err);
+            return;
+          }
           fn(err, store.identify(arr));
         });
       }
@@ -388,12 +412,24 @@ Store.prototype.first = function (query, fn) {
     , fields = stripFields(query);
 
   collection(this, function (err, col) {
+    if (err) {
+      fn(err);
+      return;
+    }
     if(fields) {
       col.findOne(query, fields, function (err, result) {
+        if (err) {
+          fn(err);
+          return;
+        }
         fn(err, store.identify(result));
       });
     } else {
       col.findOne(query, function (err, result) {
+        if (err) {
+          fn(err);
+          return;
+        }
         fn(err, store.identify(result));
       });
     }
@@ -449,7 +485,15 @@ Store.prototype.update = function (query, object, fn) {
   debug('update - command', command);
 
   collection(this, function (err, col) {
+    if (err) {
+      fn(err);
+      return;
+    }
     col.update(query, command, { multi: multi }, function (err, r) {
+      if (err) {
+        fn(err);
+        return;
+      }
       store.identify(query);
       fn(err, r ? { count: r.result.n } : null);
     }, multi);
@@ -481,6 +525,10 @@ Store.prototype.remove = function (query, fn) {
     store.identify(query);
   }
   collection(this, function (err, col) {
+    if (err) {
+      fn(err);
+      return;
+    }
     col.remove(query, function (error, r) { fn(error, r ? { count: r.result.n } : null); });
   });
 };
@@ -502,6 +550,10 @@ Store.prototype.remove = function (query, fn) {
 Store.prototype.rename = function (namespace, fn) {
   var store = this;
   collection(this, function (err, col) {
+    if (err) {
+      fn(err);
+      return;
+    }
     store.namespace = namespace;
     col.rename(namespace, fn);
   });


### PR DESCRIPTION
Add error handling inside certain callbacks in Store's methods. Despite an error being passed in and therefore no second argument such as `col` is being passed in, these callbacks assume the second argument is not `undefined` and make use of it, causing ReferenceErrors. Affected methods are as follows:
- Store.protoype.find
- Store.protoype.first
- Store.protoype.insert
- Store.protoype.update
- Store.protoype.remove
- Store.protoype.rename

No breaking changes, no GitHub issues being closed.