### PR TITLE
fix(http): Allow CORS authorization header (for non-cookie auth)

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -18,7 +18,7 @@ exports.setup = function(req, res, next) {
     corsOpts.supportsCredentials = false;
   }
 
-  corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With"]);
+  corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]);
   var handler = corser.create(corsOpts);
 
   handler(req, res, function () {


### PR DESCRIPTION
See commit cfe228f926bf3b1e7efd44b0f52edc8ae3323f7b and PR https://github.com/deployd/deployd/pull/521