### PR TITLE
fix(db): Properly report database connection issues

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -9,6 +9,9 @@ var db = module.exports = {}
   , Promise = require('bluebird')
   , _ = require('underscore');
 
+require("debug").enable("db:error");
+var error = require('debug')('db:error');
+
 /**
  * Create a new database with the given options. You can start making
  * database calls right away. They are internally buffered and executed once the
@@ -124,18 +127,28 @@ module.exports.Store = Store;
 
 function getConnection(db) {
   if (db.Db) return Promise.resolve(db.Db); // reuse connection
-  
+  if (typeof db.connectionString !== "string" || db.connectionString.length === 0) {
+    error(new Error("Cannot initialize store. A proper connection string was not specified."));
+    process.exit(1);
+  }
   return new Promise(function(resolve, reject) {
-    mongodb.MongoClient.connect(db.connectionString, function (err, database) {
-      if (!err) {
-        db.Db = database;
-        resolve(database);
-      }
-      else {
-        debug(err);
-        reject(err);
-      }
-    });
+    try {
+      mongodb.MongoClient.connect(db.connectionString, function (err, database) {
+        if (!err) {
+          db.Db = database;
+          resolve(database);
+        }
+        else {
+          // log error
+          error(new Error("Cannot open store: " + err));
+          // hide sensitive database connection error details
+          reject("Database connection error");
+        }
+      });
+    } catch(e){
+      error(e);
+      reject("Database connection error");
+    }
   });
 }
 
@@ -145,7 +158,7 @@ function collection(store, fn) {
   getConnection(db).then(function (mdb) {
     mdb.collection(store.namespace, function (err, collection) {
       if(err || !collection) {
-        console.error(err || new Error('Unable to get ' + store.namespace + ' collection'));
+        error(err || new Error('Unable to get ' + store.namespace + ' collection'));
         process.exit(1);
       }
 
@@ -251,7 +264,7 @@ Store.prototype.createUniqueIdentifier = function() {
 
 Store.prototype.insert = function (object, fn) {
   if (Array.isArray(object) && object.length === 0) {
-    // mongodb client combatibility, empty arrays not allowed any more  
+    // mongodb client combatibility, empty arrays not allowed any more
     fn(null, null);
     return;
   }
@@ -341,7 +354,7 @@ Store.prototype.find = function (query, fn) {
     , options = stripOptions(query);
 
   if (!_.isObject(fields)) fields = undefined;
-    
+
   collection(this, function (err, col) {
     if (err) {
       fn(err);

--- a/lib/session.js
+++ b/lib/session.js
@@ -7,6 +7,9 @@ var Store = require('./db').Store
 , Promise = require("bluebird")
 , _ = require("underscore");
 
+require("debug").enable("session:error");
+var error = require('debug')('session:error');
+
 /*!
 * A simple index for storing sesssions in memory.
 */
@@ -91,7 +94,7 @@ SessionStore.prototype.cleanupInactiveSessions = function () {
     ]
   }, function (err, updated) {
     if (err) {
-      console.error("Error removing old sessions: " + err);
+      error("Error removing old sessions: " + err);
     }
   });
   this.cleanupInactiveSessions.lastRun = Date.now();


### PR DESCRIPTION
Prior to this, errors thrown when the database was unavailable were not helpful. With this change, deployd will now properly output errors to the console.