### PR TITLE
fix(http): allow X-Session-* headers through CORS response

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -17,7 +17,7 @@ exports.setup = function(options, req, res, next) {
   } else {
     corsOpts.supportsCredentials = false;
   }
-
+  corsOpts.responseHeaders = corser.simpleResponseHeaders.concat(["X-Session-Token", "X-Session-Invalidated"]);
   corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]);
   var handler = corser.create(corsOpts);
 


### PR DESCRIPTION
Used to inform client of the session id, or whether the session was invalidated. Useful for auto  coordination in dpd.js between REST and socket.io.