### PR TITLE
fix(session): session rehydration via socket.io

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -23,6 +23,8 @@ var sessionIndex = {}
 */
 
 function SessionStore(namespace, db, sockets, options) {
+  var self = this;
+
   this.sockets = sockets;
   this.options = options || {};
   // sessions inactive for longer than this will be cleaned up:
@@ -42,14 +44,26 @@ function SessionStore(namespace, db, sockets, options) {
       var cookies = new Cookies(client.handshake)
         , sid = cookies.get('sid');
 
-      if(sid) {
+      var getSession = function(sid, fn) {
+        // check if we already know about the session
         var session = sessionIndex[sid];
-        if (session) {
-          // index sockets against their session id
-          socketIndex[sid] = socketIndex[sid] || {};
-          socketIndex[sid][client.id] = client;
-          socketQueue.emit(sid, client);
-        }
+        if (session) { return fn(null, session); }
+        // get the session from the store otherwise
+        self.createSession(sid, function(err, session) {
+          if (session.data.id === sid) return fn(null, session);
+          return fn();
+        });
+      };
+
+      if(sid) {
+        getSession(sid, function(err, session) {
+          if (session) {
+            // index sockets against their session id
+            socketIndex[sid] = socketIndex[sid] || {};
+            socketIndex[sid][client.id] = client;
+            socketQueue.emit(sid, client);
+          }
+        });
       }
 
       // Alternative way of binding session to socket connection
@@ -58,17 +72,19 @@ function SessionStore(namespace, db, sockets, options) {
       client.on('server:setSession', function(data) {
         if (!data || !data.sid) { return; }
         var sid = data.sid;
-        var session = sessionIndex[sid];
-        if (session) {
-          // unassign socket from previous sessions
-          _.each(socketIndex, function (val){
-            delete val[client.id];
-          });
 
-          socketIndex[sid] = socketIndex[sid] || {};
-          socketIndex[sid][client.id] = client;
-          socketQueue.emit(sid, client);
-        }
+        getSession(sid, function(err, session){
+          if (session) {
+            // unassign socket from previous sessions
+            _.each(socketIndex, function (val){
+              delete val[client.id];
+            });
+
+            socketIndex[sid] = socketIndex[sid] || {};
+            socketIndex[sid][client.id] = client;
+            socketQueue.emit(sid, client);
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
When deployd crashes or is stopped and restarted, all the sessions in the memory store are cleared, so when you reconnect via socket.io, it can't associate the connection with a valid session. Previously, all new emitToUsers messages targeting that sesssion were lost until you logged in again so your session got recreated.

This PR fixes this issue so that the session is rehydrated appropriately if a socket.io connection requests it.