### PR TITLE
fix(UserCollection): don't allow non string value as password

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -131,16 +131,23 @@ UserCollection.prototype.handle = function (ctx) {
       }
       /* falls through */
     case 'PUT':
+      function done(err, res) {
+        if (res) delete res.password;
+        ctx.done(err, res);
+      }
+
       this.setPassword(ctx.body);
+
+      // only allow strings on passwords
+      // undefined passwords will be handled by the required validation
+      if (typeof ctx.body.password !== 'string' && typeof ctx.body.password !== 'undefined') {
+        return done({errors: {password: 'is invalid; must be a string'}});
+      }
+
       var isSelf = ctx.session.user && ctx.session.user.id === ctx.query.id || (ctx.body && ctx.body.id);
       if ((ctx.query.id || ctx.body.id) && ctx.body && !isSelf && !ctx.session.isRoot && !ctx.req.internal) {
         delete ctx.body.username;
         delete ctx.body.password;
-      }
-
-      function done(err, res) {
-        if (res) delete res.password;
-        ctx.done(err, res);
       }
 
       if(ctx.query.id || ctx.body.id) {
@@ -317,8 +324,8 @@ UserCollection.prototype.handleSession = function (ctx, fn) {
  * @param {Object} body The body of the request. Must contain `body.password`.
  */
 UserCollection.prototype.setPassword = function (body) {
-  // do not add salt to empty string
-  if(!body || !body.password || body.password.length < 1) {
+  // do not add salt to truthy value or empty string
+  if(!body || !body.password || typeof body.password !== 'string' || body.password.length < 1) {
       return;
   }
   var salt = uuid.create(UserCollection.SALT_LEN);


### PR DESCRIPTION
The **user collection** uses `crypto` for password hashing and `crypto.createHash().update()` only allows to be passed strings. While the `setPassword()` method allowed truthy values to be passed over to crypto resulting on a thrown error which stops the server process.

This PR adds extra validation for string values and informs the API user about it.

```
POST /users TypeError: Not a string or buffer
    at TypeError (native)
    at Hmac.Hash.update (crypto.js:97:16)
    at UserCollection.hash (/usr/lib/node_modules/deployd/lib/resources/user-collection.js:343:44)
    at UserCollection.setPassword (/usr/lib/node_modules/deployd/lib/resources/user-collection.js:333:31)
    at UserCollection.handle (/usr/lib/node_modules/deployd/lib/resources/user-collection.js:139:12)
    at /usr/lib/node_modules/deployd/lib/router.js:82:22
    at doNTCallback0 (node.js:408:9)
    at process._tickDomainCallback (node.js:378:13)
```