### PR TITLE
feature(script): $addCallback $finishCallback

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -44,6 +44,7 @@ Script.prototype.run = function (ctx, domain, fn) {
 
   var req = ctx.req
     , session = ctx.session
+    , waitingForCallback = false
     , callbackCount = 0
     , events;
 
@@ -94,6 +95,7 @@ Script.prototype.run = function (ctx, domain, fn) {
   if(domain) {
 
     events.on('addCallback', function() {
+      waitingForCallback = true;
       callbackCount++;
     });
 
@@ -140,7 +142,7 @@ Script.prototype.run = function (ctx, domain, fn) {
   }
   err = err || scriptContext._error;
   process.nextTick(function () {
-    if (callbackCount <= 0) {
+    if (!waitingForCallback && callbackCount <= 0) {
       done(err);
     }
   });

--- a/lib/script.js
+++ b/lib/script.js
@@ -14,13 +14,13 @@ function Script(src, path) {
 
 Script.prototype.runWithContext = function (context) {
   var functionArgs = Object.keys(context);
-  
+
   // remove the argument 'this' from our list of passed arguments, because it is a reserved word
   functionArgs.splice(functionArgs.indexOf('this'), 1);
-  
+
   functionArgs.push(this.scriptSourceCode);
   var func = Function.apply(null, functionArgs);
-    
+
   // pass our arguments from the sandbox to the function
   var args = [];
   functionArgs.forEach(function (p) {
@@ -34,9 +34,9 @@ Script.prototype.runWithContext = function (context) {
  */
 
 Script.prototype.run = function (ctx, domain, fn) {
-  
+
   if (this.error) { fn(this.error); }
-  
+
   if(typeof domain === 'function') {
     fn = domain;
     domain = undefined;
@@ -46,7 +46,7 @@ Script.prototype.run = function (ctx, domain, fn) {
     , session = ctx.session
     , callbackCount = 0
     , events;
-  
+
   var scriptContext = {
     'this': {},
     cancel: function(msg, status) {
@@ -80,17 +80,17 @@ Script.prototype.run = function (ctx, domain, fn) {
     },
     ctx: ctx
   };
-  
+
   scriptContext._this = scriptContext['this'];
   scriptContext._error = undefined;
-  
+
   events = new EventEmitter();
-  
+
   function done(err) {
     events.removeAllListeners('finishCallback');
     if (fn) fn(err);
   }
-  
+
   if(domain) {
 
     events.on('addCallback', function() {
@@ -103,13 +103,20 @@ Script.prototype.run = function (ctx, domain, fn) {
         done(scriptContext._error);
       }
     });
-    
+
     events.on('error', function (err) {
       done(err);
     });
-    
+
+    domain.$addCallback = function() {
+      events.emit('addCallback');
+    };
+
+    domain.$finishCallback = function() {
+      events.emit('finishCallback');
+    };
     domain.dpd = ctx.dpd;
-    
+
     if(fn) {
       // if a callback is expected, count callbacks
       // and manually merge the domain
@@ -124,7 +131,7 @@ Script.prototype.run = function (ctx, domain, fn) {
   }
 
   var err;
-  
+
   try {
     this.runWithContext(scriptContext);
   } catch(e) {
@@ -159,7 +166,7 @@ function wrapError(err) {
 function isPromise(obj) {
   //maybe not the best of all checks but at least it's compliant to Promises/A+
   //see https://promisesaplus.com
-  return typeof obj === 'object' && (typeof obj.then === 'function' || isPromise(obj.promise));
+  return obj !== null && typeof obj === 'object' && (typeof obj.then === 'function' || isPromise(obj.promise));
 }
 
 function wrapPromise(promiseable, sandbox, events, done, sandboxRoot) {
@@ -181,13 +188,13 @@ function wrapPromise(promiseable, sandbox, events, done, sandboxRoot) {
   var finishCallback = function() {
     events.emit('finishCallback');
   };
-  
+
   addCallback();
   realPromise.then(finishCallback, finishCallback);
-    
+
   realPromise._then = function (onFulfilled, onRejected) {
     var args = [undefined, undefined];
-    
+
     if (onFulfilled) {
       // wrappedOnFulfilled
       args[0] = function (res) {
@@ -224,7 +231,7 @@ function wrapPromise(promiseable, sandbox, events, done, sandboxRoot) {
           }
         };
     }
-      
+
     for(var i = args.length; i< arguments.length; i++) {
       args[i] = arguments[i];
     }
@@ -242,7 +249,7 @@ function wrapAsyncFunction(asyncFunction, sandbox, events, done, sandboxRoot) {
     var callback;
     var callbackIndex;
     var result;
-    
+
     for(var i = 0; i < args.length; i++) {
       if(typeof args[i] == 'function') {
         callback = args[i];
@@ -250,7 +257,7 @@ function wrapAsyncFunction(asyncFunction, sandbox, events, done, sandboxRoot) {
         break;
       }
     }
-    
+
     if (typeof callback === 'function') {
       events.emit('addCallback');
       args[callbackIndex] = function() {
@@ -272,7 +279,7 @@ function wrapAsyncFunction(asyncFunction, sandbox, events, done, sandboxRoot) {
       sandbox._error = wrappedErr;
       return done(wrappedErr);
     }
-    
+
     if(result !== undefined) {
       if(isPromise(result)) {
         return wrapPromise(result, sandbox, events, done, sandboxRoot);

--- a/test/script.unit.js
+++ b/test/script.unit.js
@@ -7,7 +7,7 @@ describe('script', function(){
       var s = new Script('2 + 2');
       s.run({}, done);
     });
-    
+
     it('should always have access to cancel()', function(done) {
       var s = new Script('cancel()');
       s.run({}, function (e) {
@@ -15,7 +15,7 @@ describe('script', function(){
         done();
       });
     });
-    
+
     it('should have access to the current user if one exists', function(done) {
       var s = new Script('if(!me) throw "no user"');
       var session = {
@@ -24,7 +24,7 @@ describe('script', function(){
       s.run({session: session}, done);
     });
   });
-  
+
   describe('.run(ctx, domain, fn)', function(){
     it('should expose the domain directly to the script', function(done) {
       var s = new Script('if(!foo) throw "foo not passed"');
@@ -35,7 +35,7 @@ describe('script', function(){
       var s = new Script('if(previous.foo !== null) throw "foo was " + JSON.stringify(previous.foo)');
       s.run({}, { previous: { foo: null } }, done);
     });
-    
+
     it('should not be slow and leak memory', function (done) {
       var s = new Script('if(!foo) throw "foo not passed"');
       var time = Date.now();
@@ -49,7 +49,7 @@ describe('script', function(){
         });
       }
     });
-      
+
     it('should callback with error on script syntax error', function (done) {
       var s = new Script('if(!foo throw "foo not passed"');
       s.run({ }, { foo: 123 }, function (err) {
@@ -60,6 +60,22 @@ describe('script', function(){
   });
 
   describe('async', function(){
+    it('should allow manual callback counting', function(done) {
+      this.timeout(200);
+      var s = new Script('$addCallback(); async(function() { setTimeout(function() { inc(); $finishCallback(); }, 20); }, 20)');
+      var i = 0;
+      function inc() {
+        i++;
+      }
+
+      s.run({}, {async: function(fn){
+        setTimeout(fn, 50);
+      }, inc: inc}, function () {
+        expect(i).to.equal(1);
+        done();
+      });
+    });
+
     it('should return after all callbacks are complete', function(done) {
       this.timeout(200);
       var s = new Script('setTimeout(function() { inc() }, 50)');
@@ -67,22 +83,22 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();
       });
     });
-    
+
     it('should callback even an error occurs asynchronously', function(done) {
       var s = new Script('setTimeout(function() { throw "test err" }, 22)');
-      
+
       s.run({}, {setTimeout: setTimeout}, function (e) {
         expect(e).to.exist;
         done();
       });
     });
-    
+
     it('should return errors even when nested in objects', function(done) {
       var domain = {
         foo: {
@@ -96,16 +112,16 @@ describe('script', function(){
           }
         }
       };
-      
+
       var s = new Script('foo.bar.baz(function() {  })');
-      
+
       s.run({}, domain, function (e) {
         expect(e).to.exist;
-        
+
         done();
       });
-      
-      
+
+
     });
   });
 
@@ -117,7 +133,7 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();
@@ -131,7 +147,7 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();
@@ -145,7 +161,7 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();
@@ -159,7 +175,7 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();
@@ -173,7 +189,7 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();
@@ -187,7 +203,7 @@ describe('script', function(){
       function inc() {
         i++;
       }
-      
+
       s.run({}, {aye: ayepromise, setTimeout: setTimeout, inc: inc}, function () {
         expect(i).to.equal(1);
         done();


### PR DESCRIPTION
Add manual callback handling, for when you need to `require` other node functions that do not play well with deployd's automatic async callback handling.

Call `$addCallback()` before calling an async function to increment the counter, and `$finishCallback()` when the callback is finished to decrement the counter. When the counter is 0, deployd will return the response.