### PR TITLE
feature(collection): Add `previous` to AfterCommit event

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -480,8 +480,13 @@ Collection.prototype.save = function (ctx, fn) {
 
   var domain = createDomain(item, errors);
 
+  domain.protectedKeys = [];
+
   domain.protect = function(property) {
-    delete domain.data[property];
+    if (domain.data.hasOwnProperty(property)) {
+      domain.protectedKeys.push(property);
+      delete domain.data[property];
+    }
   };
 
   domain.changed =  function (property) {
@@ -555,7 +560,7 @@ Collection.prototype.save = function (ctx, fn) {
         store.update({id: query.id}, item, function (err) {
           if(err) return done(err);
           item.id = id;
-          collection.doAfterCommitEvent('PUT', ctx, item, prev);
+          collection.doAfterCommitEvent('PUT', ctx, item, prev, domain.protectedKeys);
           done(null, item);
         });
       }
@@ -644,9 +649,16 @@ function createDomain(data, errors) {
   return domain;
 }
 
-Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous){
+Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous, protectedKeys) {
   var collection = this;
   if (collection.shouldRunEvent(collection.events.AfterCommit, ctx)) {
+    data = _.clone(data);
+    if (protectedKeys && protectedKeys.length > 0 && previous) {
+      // add back whatever fields were protected, because they are removed from data
+      protectedKeys.forEach(function (key) {
+        data[key] = previous[key];
+      });
+    }
     collection.events.AfterCommit.run(ctx, {data: data, 'this': data, method: method, previous: previous}, function (err) {
       if (err) debug('AfterCommit errors in script: %j', err);
     });

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -376,7 +376,7 @@ Collection.prototype.remove = function (ctx, fn) {
     if(err) {
       return fn(err);
     }
-    
+
     // if a single id was passed and it wasn't found, we'll get undefined
     // convert it to an empty array which will be handled below
     if (typeof result === 'undefined') {
@@ -386,15 +386,15 @@ Collection.prototype.remove = function (ctx, fn) {
     if (!Array.isArray(result)) {
       result = [result];
     }
-    
+
     // nothing to delete
     if (result.length === 0) {
       return fn(null, { count: 0 });
     }
-      
+
     var remaining = result.length
       , idsToDelete = [];
-      
+
     function done(data, err) {
       var id = data.id;
       remaining--;
@@ -402,7 +402,7 @@ Collection.prototype.remove = function (ctx, fn) {
         // we only have one row to delete but an error has occured, pass it through
         return fn(err);
       }
-      
+
       if (err && err instanceof Error) {
         // only halt execution if an actual error was thrown from the script
         // cancel() from within the script is not an instance of Error, so it will be ignored by this
@@ -555,7 +555,7 @@ Collection.prototype.save = function (ctx, fn) {
         store.update({id: query.id}, item, function (err) {
           if(err) return done(err);
           item.id = id;
-          collection.doAfterCommitEvent('PUT', ctx, item);
+          collection.doAfterCommitEvent('PUT', ctx, item, prev);
           done(null, item);
         });
       }
@@ -580,6 +580,14 @@ Collection.prototype.save = function (ctx, fn) {
     // generate id before event listener
     item.id = store.createUniqueIdentifier();
 
+    function commit(){
+      store.insert(item, function(err, data) {
+        if (err) return done(err);
+        collection.doAfterCommitEvent('POST', ctx, item);
+        done(null, data);
+      });
+    }
+
     if(collection.shouldRunEvent(collection.events.Post, ctx)) {
       collection.events.Post.run(ctx, domain, function (err) {
         if(err) {
@@ -588,12 +596,11 @@ Collection.prototype.save = function (ctx, fn) {
         }
         if(err || domain.hasErrors()) return done(err || errors);
         debug('inserting item', item);
-        collection.doAfterCommitEvent('POST', ctx, item);
-        store.insert(item, done);
+
+        commit();
       });
     } else {
-      collection.doAfterCommitEvent('POST', ctx, item);
-      store.insert(item, done);
+      commit();
     }
   }
 
@@ -637,11 +644,11 @@ function createDomain(data, errors) {
   return domain;
 }
 
-Collection.prototype.doAfterCommitEvent = function(method, ctx, data){
+Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous){
   var collection = this;
   if (collection.shouldRunEvent(collection.events.AfterCommit, ctx)) {
-    collection.events.AfterCommit.run(ctx, {data: data, 'this': data, method: method}, function (err) { 
-      if (err) debug('AfterCommit errors in script: %j', err); 
+    collection.events.AfterCommit.run(ctx, {data: data, 'this': data, method: method, previous: previous}, function (err) {
+      if (err) debug('AfterCommit errors in script: %j', err);
     });
   }
 };


### PR DESCRIPTION
Also fix POST so that AfterCommit is called after successful database insertion rather than before it.