### PR TITLE
feature(internal-client): pass through headers and connection

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -12,13 +12,13 @@ var internalClient = require('./internal-client')
  * - **url** `String` The url of the request, stripped of the resource's base path
  * - **body** `Object` The body of the request, if the body is JSON or url encoded
  * - **query** `Object` The query of the request
- * 
+ *
  * @param {Resource} resource
  * @param {HttpRequest} req
  * @param {HttpResponse} res
  * @param {Server} server
  */
- 
+
 function Context(resource, req, res, server) {
   var ctx = this;
   this.url = req.url.slice(resource.path.length).split('?')[0];
@@ -31,7 +31,7 @@ function Context(resource, req, res, server) {
   this.server = server;
   this.session = req.session;
   this.method = req && req.method;
-  
+
   // always bind done to this
   var done = this.done;
   this.done = function() {
@@ -44,7 +44,7 @@ function Context(resource, req, res, server) {
     req.stack.recursionLimit = recursionLimit;
   }
 
-  this.dpd = internalClient.build(server, req.session, req.stack);
+  this.dpd = internalClient.build(server, req.session, req.stack, ctx);
 }
 
 /**
@@ -58,13 +58,13 @@ Context.prototype.end = function() {
  * Continuous callback sugar for easily calling res.end().
  *
  * Example:
- *     
+ *
  *     // instead of
  *     store.find({foo: 'bar'}, function(err, res) {
  *       if(err) return res.end(JSON.stringify(err));
- *       res.end(JSON.stringify(res));   
+ *       res.end(JSON.stringify(res));
  *     })
- * 
+ *
  *     // you can just do
  *     store.find({foo: 'bar'}, ctx.done);
  *
@@ -75,9 +75,9 @@ Context.prototype.end = function() {
 Context.prototype.done = function(err, res) {
   var body = res
     , type = 'application/json';
-  
+
   // default response
-  var status = this.res.statusCode = this.res.statusCode || 200; 
+  var status = this.res.statusCode = this.res.statusCode || 200;
 
   if(err) {
     debug('%j', err);

--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -56,7 +56,7 @@ function joinPath() {
 
 
 
-exports.build = function(server, session, stack) {
+exports.build = function(server, session, stack, ctx) {
   var baseMethods
     , dpd = {};
 
@@ -77,7 +77,8 @@ exports.build = function(server, session, stack) {
         , session: session
         , isRoot: session && session.isRoot
         , internal: true
-        , headers: {}
+        , headers: ctx.req ? (ctx.req.headers || {}) : {}
+        , connection: ctx.req ? (ctx.req.connection || {}) : {}
         , on: function() {}
       };
 
@@ -160,11 +161,11 @@ exports.build = function(server, session, stack) {
     server.resources.forEach(function(r) {
       if (r.clientGeneration) {
         var jsName = r.path.replace(/[^A-Za-z0-9]/g, '');
-        dpd[jsName] = createResourceClient(r, baseMethods);  
+        dpd[jsName] = createResourceClient(r, baseMethods);
       }
-    });  
+    });
   }
-  
+
   return dpd;
 };
 
@@ -271,7 +272,7 @@ function parseGetSignature(args) {
   }
 
   if (typeof args[i] === 'function') {
-    settings.fn = args[i];  
+    settings.fn = args[i];
   }
 
   return settings;
@@ -301,7 +302,7 @@ function parsePostSignature(args) {
   }
 
   if (typeof args[i] === 'function') {
-    settings.fn = args[i];  
+    settings.fn = args[i];
   }
 
   return settings;


### PR DESCRIPTION
The internal-client did not pass through headers and connection data from the initial calling context, so things like the IP address and User Agent etc were lost with internal calls.

This properly passes through the context.