### PR TITLE
feature(collection): add BeforeRequest event

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -37,7 +37,7 @@ Collection.external = {};
 Collection.prototype.clientGeneration = true;
 Collection.domainAdditions = {};
 
-Collection.events  = ['Get', 'Validate', 'Post', 'Put', 'Delete', 'AfterCommit'];
+Collection.events  = ['Get', 'Validate', 'Post', 'Put', 'Delete', 'AfterCommit', 'BeforeRequest'];
 Collection.dashboard = {
     path: path.join(__dirname, 'dashboard')
   , pages: ['Properties', 'Data', 'Events', 'API']
@@ -304,54 +304,65 @@ Collection.prototype.find = function (ctx, fn) {
     fn(null, result);
   }
 
-  debug('finding %j; sanitized %j', query, sanitizedQuery);
+  function doFind() {
+    // resanitize query in case it was modified from BeforeRequest event
+    sanitizedQuery = collection.sanitizeQuery(query);
 
-  store.find(sanitizedQuery, function (err, result) {
-    debug("Find Callback");
-    if(err) return done(err);
-    debug('found %j', err || result || 'none');
-    if(!collection.shouldRunEvent(collection.events.Get, ctx)) {
-      return done(err, result);
-    }
+    debug('finding %j; sanitized %j', query, sanitizedQuery);
+    store.find(sanitizedQuery, function (err, result) {
+      debug("Find Callback");
+      if(err) return done(err);
+      debug('found %j', err || result || 'none');
+      if(!collection.shouldRunEvent(collection.events.Get, ctx)) {
+        return done(err, result);
+      }
 
-    var errors = {};
+      var errors = {};
 
-    if(Array.isArray(result)) {
+      if(Array.isArray(result)) {
 
-      var remaining = result && result.length;
-      if(!remaining) return done(err, result);
-      result.forEach(function (data) {
+        var remaining = result && result.length;
+        if(!remaining) return done(err, result);
+        result.forEach(function (data) {
+          // domain for onGet event scripts
+          var domain = collection.createDomain(data, errors);
+
+          collection.events.Get.run(ctx, domain, function (err) {
+            if (err) {
+              if (err instanceof Error) {
+                return done(err);
+              } else {
+                errors[data.id] = err;
+              }
+            }
+
+            remaining--;
+            if(!remaining) {
+              done(null, result.filter(function(r) {
+                return !errors[r.id];
+              }));
+            }
+          });
+        });
+      } else {
         // domain for onGet event scripts
+        data = result;
         var domain = collection.createDomain(data, errors);
 
         collection.events.Get.run(ctx, domain, function (err) {
-          if (err) {
-            if (err instanceof Error) {
-              return done(err);
-            } else {
-              errors[data.id] = err;
-            }
-          }
+          if(err) return done(err);
 
-          remaining--;
-          if(!remaining) {
-            done(null, result.filter(function(r) {
-              return !errors[r.id];
-            }));
-          }
+          done(null, data);
         });
-      });
-    } else {
-      // domain for onGet event scripts
-      data = result;
-      var domain = collection.createDomain(data, errors);
+      }
+    });
+  }
 
-      collection.events.Get.run(ctx, domain, function (err) {
-        if(err) return done(err);
-
-        done(null, data);
-      });
-    }
+  var beforeRequestDomain = { event: "GET" };
+  collection.addDomainAdditions(beforeRequestDomain);
+  collection.doBeforeRequestEvent(ctx, beforeRequestDomain, function(err) {
+    if (err) return fn(err);
+    doFind();
   });
 };
 
@@ -373,62 +384,72 @@ Collection.prototype.remove = function (ctx, fn) {
     , errors;
 
   if(!(query && query.id)) return fn('You must include a query with an id when deleting an object from a collection.');
-  store.find(sanitizedQuery, function (err, result) {
-    if(err) {
-      return fn(err);
-    }
 
-    // if a single id was passed and it wasn't found, we'll get undefined
-    // convert it to an empty array which will be handled below
-    if (typeof result === 'undefined') {
-      result = [];
-    }
-    // convert result to an array if it is not
-    if (!Array.isArray(result)) {
-      result = [result];
-    }
-
-    // nothing to delete
-    if (result.length === 0) {
-      return fn(null, { count: 0 });
-    }
-
-    var remaining = result.length
-      , idsToDelete = [];
-
-    function done(data, err) {
-      var id = data.id;
-      remaining--;
-      if (result.length === 1 && err) {
-        // we only have one row to delete but an error has occured, pass it through
+  function doRemove() {
+    store.find(sanitizedQuery, function (err, result) {
+      if(err) {
         return fn(err);
       }
 
-      if (err && err instanceof Error) {
-        // only halt execution if an actual error was thrown from the script
-        // cancel() from within the script is not an instance of Error, so it will be ignored by this
-        return fn(err);
-      } else if (!err) {
-        // script executed without an error, this id will be deleted
-        idsToDelete.push(id);
+      // if a single id was passed and it wasn't found, we'll get undefined
+      // convert it to an empty array which will be handled below
+      if (typeof result === 'undefined') {
+        result = [];
+      }
+      // convert result to an array if it is not
+      if (!Array.isArray(result)) {
+        result = [result];
       }
 
-      if(!remaining) {
-        store.remove({ id: { $in: idsToDelete } }, function(){
-          collection.doAfterCommitEvent('DELETE', ctx, data);
-          fn.apply(null, arguments);
-        });
+      // nothing to delete
+      if (result.length === 0) {
+        return fn(null, { count: 0 });
       }
-    }
 
-    result.forEach(function(data) {
-      if (collection.shouldRunEvent(collection.events.Delete, ctx)) {
-        var domain = collection.createDomain(data, errors);
-        collection.events.Delete.run(ctx, domain, function (err) { done(data, err);  });
-      } else {
-        done(data);
+      var remaining = result.length
+        , idsToDelete = [];
+
+      function done(data, err) {
+        var id = data.id;
+        remaining--;
+        if (result.length === 1 && err) {
+          // we only have one row to delete but an error has occured, pass it through
+          return fn(err);
+        }
+
+        if (err && err instanceof Error) {
+          // only halt execution if an actual error was thrown from the script
+          // cancel() from within the script is not an instance of Error, so it will be ignored by this
+          return fn(err);
+        } else if (!err) {
+          // script executed without an error, this id will be deleted
+          idsToDelete.push(id);
+        }
+
+        if(!remaining) {
+          store.remove({ id: { $in: idsToDelete } }, function(){
+            collection.doAfterCommitEvent('DELETE', ctx, data);
+            fn.apply(null, arguments);
+          });
+        }
       }
+
+      result.forEach(function(data) {
+        if (collection.shouldRunEvent(collection.events.Delete, ctx)) {
+          var domain = collection.createDomain(data, errors);
+          collection.events.Delete.run(ctx, domain, function (err) { done(data, err);  });
+        } else {
+          done(data);
+        }
+      });
     });
+  }
+
+  var beforeRequestDomain = { event: "DELETE" };
+  collection.addDomainAdditions(beforeRequestDomain);
+  collection.doBeforeRequestEvent(ctx, beforeRequestDomain, function(err) {
+    if (err) return fn(err);
+    doRemove();
   });
 };
 
@@ -480,8 +501,6 @@ Collection.prototype.save = function (ctx, fn) {
   }
 
   var domain = collection.createDomain(item, errors);
-
-  domain.protectedKeys = [];
 
   domain.protectedKeys = [];
 
@@ -612,15 +631,28 @@ Collection.prototype.save = function (ctx, fn) {
     }
   }
 
+  var beforeRequestDomain = { event: "POST", data: item };
+  collection.addDomainAdditions(beforeRequestDomain);
+
   if (query.id) {
-    put();
+    beforeRequestDomain.event = "PUT";
+    collection.doBeforeRequestEvent(ctx, beforeRequestDomain, function(err) {
+      if (err) return fn(err);
+      put();
+    });
   } else if (collection.shouldRunEvent(collection.events.Validate, ctx)) {
-    collection.events.Validate.run(ctx, domain, function (err) {
-      if(err || domain.hasErrors()) return done(err || errors);
-      post();
+    collection.doBeforeRequestEvent(ctx, beforeRequestDomain, function(err) {
+      if (err) return fn(err);
+      collection.events.Validate.run(ctx, domain, function (err) {
+        if(err || domain.hasErrors()) return done(err || errors);
+        post();
+      });
     });
   } else {
-    post();
+    collection.doBeforeRequestEvent(ctx, beforeRequestDomain, function(err) {
+      if (err) return fn(err);
+      post();
+    });
   }
 };
 
@@ -651,6 +683,12 @@ Collection.prototype.createDomain = function(data, errors) {
     'this': data,
     data: data
   };
+  collection.addDomainAdditions(domain);
+  return domain;
+};
+
+Collection.prototype.addDomainAdditions = function(domain) {
+  var collection = this;
   _.each(Collection.domainAdditions, function(value, name) {
     if (typeof value === "function") {
       // bind `this` to collection on any added functions
@@ -659,7 +697,6 @@ Collection.prototype.createDomain = function(data, errors) {
       domain[name] = value;
     }
   });
-  return domain;
 };
 
 Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous, protectedKeys) {
@@ -675,6 +712,15 @@ Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous, 
     collection.events.AfterCommit.run(ctx, {data: data, 'this': data, method: method, previous: previous}, function (err) {
       if (err) debug('AfterCommit errors in script: %j', err);
     });
+  }
+};
+
+Collection.prototype.doBeforeRequestEvent = function(ctx, domain, fn) {
+  var collection = this;
+  if (collection.shouldRunEvent(collection.events.BeforeRequest, ctx)) {
+    collection.events.BeforeRequest.run(ctx, domain, fn);
+  } else {
+    fn();
   }
 };
 

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -709,7 +709,9 @@ Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous, 
         data[key] = previous[key];
       });
     }
-    collection.events.AfterCommit.run(ctx, {data: data, 'this': data, method: method, previous: previous}, function (err) {
+    var domain = {data: data, 'this': data, method: method, previous: previous};
+    collection.addDomainAdditions(domain);
+    collection.events.AfterCommit.run(ctx, domain, function (err) {
       if (err) debug('AfterCommit errors in script: %j', err);
     });
   }

--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -59,8 +59,13 @@ UserCollection.prototype.handle = function (ctx) {
   }
 
   if(ctx.url === '/logout') {
-    if (ctx.res.cookies) ctx.res.cookies.set('sid', null, {overwrite: true});
-    ctx.session.remove(ctx.done);
+    var logoutDomain = { event: "LOGOUT" };
+    uc.addDomainAdditions(logoutDomain);
+    uc.doBeforeRequestEvent(ctx, logoutDomain, function(err) {
+      if (err) return ctx.done(err);
+      if (ctx.res.cookies) ctx.res.cookies.set('sid', null, {overwrite: true});
+      ctx.session.remove(ctx.done);
+    });
     return;
   }
 
@@ -126,7 +131,12 @@ UserCollection.prototype.handle = function (ctx) {
     break;
     case 'POST':
       if(ctx.url === '/login') {
-        this.handleLogin(ctx);
+        var loginDomain = { event: "LOGOUT" };
+        uc.addDomainAdditions(loginDomain);
+        uc.doBeforeRequestEvent(ctx, loginDomain, function(err) {
+          if (err) return ctx.done(err);
+          uc.handleLogin(ctx);
+        });
         break;
       }
       /* falls through */

--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -118,6 +118,7 @@ UserCollection.prototype.handle = function (ctx) {
           if (ctx.session.data.userhash === userHash) {
             // hash verified, call find() now to ensure all event scripts are executed
             return uc.find(ctx, function(err, user){
+              if (!user) return noSuchUser(); // if the request was cancelled by the event script
               delete user.password;
               ctx.done.apply(null, arguments);
             });

--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -132,7 +132,7 @@ UserCollection.prototype.handle = function (ctx) {
     break;
     case 'POST':
       if(ctx.url === '/login') {
-        var loginDomain = { event: "LOGOUT" };
+        var loginDomain = { event: "LOGIN" };
         uc.addDomainAdditions(loginDomain);
         uc.doBeforeRequestEvent(ctx, loginDomain, function(err) {
           if (err) return ctx.done(err);

--- a/test-app/resources/test-before-request/beforerequest.js
+++ b/test-app/resources/test-before-request/beforerequest.js
@@ -1,0 +1,22 @@
+switch (event) {
+    case "GET":
+        if (ctx.query.secretKey !== "secret!") {
+            cancel("GET not authorized", 401);
+        }
+        ctx.query.$limit = 1;
+        break;
+    case "PUT":
+        if (this.data.foo === "bar" && ctx.body.secretKey !== "secret!") {
+            cancel("PUT not authorized, data ok", 401);
+        } else if (this.data.foo !== "bar") {
+            cancel("bad input", 500);
+        }
+        break;
+    case "POST":
+        if (this.data.foo === "bar" && ctx.body.secretKey !== "secret!") {
+            cancel("POST not authorized, data ok", 401);
+        } else if (this.data.foo !== "bar") {
+            cancel("bad input", 500);
+        }
+        break;
+}

--- a/test-app/resources/test-before-request/config.json
+++ b/test-app/resources/test-before-request/config.json
@@ -1,0 +1,13 @@
+{
+	"type": "Collection",
+	"properties": {
+		"data": {
+			"name": "data",
+			"type": "object",
+			"typeLabel": "object",
+			"required": false,
+			"id": "data",
+			"order": 0
+		}
+	}
+}


### PR DESCRIPTION
New event that allows inspecting a request prior to the database being touched, and before every other event is executed.

Allows canceling the request early (for example for authorization purposes), or modifying the query before it is executed by mongo depending on custom logic written in the event.

Gives access to `me`, `ctx`, `event` (one of: GET, PUT, POST, LOGIN, LOGOUT) variables in the event script. You can use all the `cancel()` related methods and end the request right there.

On PUT or POST, there are two additional variables available: `this` and `data` - containing the item being saved.