### PR TITLE
fix(collection): object queries on booleans would be converted to false

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -156,7 +156,7 @@ Collection.prototype.sanitizeQuery = function (query) {
       sanitized[key] = '' + val;
     } else if(expected == 'number' && actual == 'string') {
       sanitized[key] = parseFloat(val);
-    } else if(expected == 'boolean' && actual != 'boolean') {
+    } else if(expected == 'boolean' && actual == 'string') {
       sanitized[key] = (val === 'true') ? true : false;
     } else if(expected == 'object') {
       sanitized[key] = val;

--- a/test/collection.unit.js
+++ b/test/collection.unit.js
@@ -105,6 +105,29 @@ describe('collection', function(){
       var sanitized = r.sanitizeQuery({token: 123456});
       expect(sanitized.token).to.equal('123456');
     });
+
+    it('should convert string to boolean', function() {
+      var r = createCollection({
+        bool: {
+          type: 'boolean'
+        }
+      });
+
+      var sanitized = r.sanitizeQuery({bool: "true"});
+      expect(sanitized.bool).to.equal(true);
+    });
+
+
+    it('should allow object query on booleans', function() {
+      var r = createCollection({
+        bool: {
+          type: 'boolean'
+        }
+      });
+
+      var sanitized = r.sanitizeQuery({bool: { $ne: true }});
+      expect(sanitized.bool).to.eql({$ne: true});
+    });
   });
 
   describe('.handle(ctx)', function(){


### PR DESCRIPTION
Before this fix, trying to do a query like {$exists: true}, or {$ne: true} on a boolean would replace the entire query with "false", leading to very hard to track bugs.