### PR TITLE
chore: update socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "semver": "^4.3.3",
     "send": "^0.12.2",
     "shelljs": "^0.4.0",
-    "socket.io": "automattic/socket.io#93b571406e3d8f950d9132d3f88bc55d055a6b13",
+    "socket.io": "^1.3.6",
     "step": "^0.0.5",
     "underscore": "^1.7.0",
     "validation": "*",


### PR DESCRIPTION
This permanently fixes an issue with installing on Windows, for which we had the version pinned to a specific commit previously.