### PR TITLE
feature(http): cache OPTIONS request for 5 minutes

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -10,7 +10,7 @@ var Cookies = require('cookies')
 
 exports.setup = function(options, req, res, next) {
   var remoteHost = req.headers.origin
-    , corsOpts = {supportsCredentials: true, methods: ALLOWED_METHODS};
+    , corsOpts = {supportsCredentials: true, methods: ALLOWED_METHODS, maxAge: 300};
 
   if(remoteHost) {
     corsOpts.origins = options.origins;


### PR DESCRIPTION
This should reduce the number of OPTIONS requests for CORS calls to deployd. Set at five minutes, because Safari won't respect higher values anyway, and Chrome caps it at 10 minutes.