### PR TITLE
feature(http): option to allow dpd-ssh-key via CORS

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -19,6 +19,10 @@ exports.setup = function(options, req, res, next) {
   }
   corsOpts.responseHeaders = corser.simpleResponseHeaders.concat(["X-Session-Token", "X-Session-Invalidated"]);
   corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]);
+  if (options.allowCorsRootRequests) {
+    corsOpts.requestHeaders.push("dpd-ssh-key");
+  }
+
   var handler = corser.create(corsOpts);
 
   handler(req, res, function () {


### PR DESCRIPTION
Required in certain circumstances (such as running unit tests across domains/ports)

Used like:

```javascript
var server = deployd({
    port: port,
    env: process.env.ENV || 'development',
    db: {
        connectionString: process.env.MONGO_URI
    },
    allowCorsRoot: true // allow root access (dpd-ssh-key) via cors
});
```