### PR TITLE
feature(internal-client): allow access to underlying resource

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -155,19 +155,32 @@ function getConnection(db) {
 function collection(store, fn) {
   var db = store._db;
 
-  getConnection(db).then(function (mdb) {
-    mdb.collection(store.namespace, function (err, collection) {
-      if(err || !collection) {
-        error(err || new Error('Unable to get ' + store.namespace + ' collection'));
-        process.exit(1);
-      }
+  return getConnection(db).then(function (mdb) {
+    return new Promise(function(resolve, reject) {
+      mdb.collection(store.namespace, function (err, collection) {
+        if(err || !collection) {
+          error(err || new Error('Unable to get ' + store.namespace + ' collection'));
+          process.exit(1);
+        }
 
-      fn(null, collection);
+        if (fn) fn(null, collection);
+        resolve(collection);
+      });
     });
   }).catch(function (err) {
-    return fn(err);
+    if (fn) fn(err);
+    throw err;
   });
 }
+
+/**
+ * Returns a promise, or calls fn with the mongo collection served by this store
+ * @param  {Function} fn   a callback that will receive the mongo collection as the second parameter
+ * @return {Promise}       returns a promise with the mongo collection
+ */
+Store.prototype.getCollection = function(fn){
+  return collection(this, fn);
+};
 
 /**
  * Change public IDs to private IDs.

--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -237,6 +237,8 @@ function createResourceClient(resource, baseMethods) {
     };
   });
 
+  r.getResource = function() { return resource; };
+
   return r;
 }
 


### PR DESCRIPTION
Allows access to resource internals from dpd internal client. 
Adds `getCollection()` method to store, which gives access to mongodb directly so you can run raw queries, for example from [dpd-event](https://github.com/deployd/dpd-event) scripts

Allows event script syntax such as:

```javascript
// callback
dpd.colname.getResource().store.getCollection(function(err, col) {
  // use col directly here, see mongodb documentation
});

// promise
dpd.colname.getResource().store.getCollection().then(function(col) {
  // use col directly here, see mongodb documentation
});
```