### PR TITLE
fix(bin/dpd): prevent process quit when latestversion is not writable

### DIFF
--- a/bin/dpd
+++ b/bin/dpd
@@ -298,7 +298,9 @@ function checkForUpdates() {
 
       if (json && json['dist-tags'] && json['dist-tags'].latest) {
         var latest = json['dist-tags'].latest;
-        fs.writeFile(latestversionFile, latest);
+        fs.writeFile(latestversionFile, latest, function(err){
+          // Need this callback function to prevent the process being killed, when latestversionFile is NOT writable
+        });
       }
     }
   });


### PR DESCRIPTION
Fix #599 and #524