### PR TITLE
fix(internal-client): add null check for ctx

### DIFF
--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -77,8 +77,8 @@ exports.build = function(server, session, stack, ctx) {
         , session: session
         , isRoot: session && session.isRoot
         , internal: true
-        , headers: ctx.req ? (ctx.req.headers || {}) : {}
-        , connection: ctx.req ? (ctx.req.connection || {}) : {}
+        , headers: (ctx && ctx.req) ? (ctx.req.headers || {}) : {}
+        , connection: (ctx && ctx.req) ? (ctx.req.connection || {}) : {}
         , on: function() {}
       };
 


### PR DESCRIPTION
Added check for ctx variable.

Ctx is undefined when using internal client from a custom module. This would cause a `TypeError: Cannot read property 'req' of undefined` on line 80. 

This patch fixes this by checking for ctx. 