### PR TITLE
using require() without the command line

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -2,6 +2,7 @@ var _ = require('underscore')._
   , EventEmitter = require('events').EventEmitter
   , fs = require('fs')
   , bluebird = require('bluebird')
+  , br = require("base-require")
   , util = require('util');
 
 /**
@@ -52,6 +53,9 @@ Script.prototype.run = function (ctx, domain, fn) {
       };
       domain.context = function() { // access Context via context()
         return ctx;
+      };
+      domain.requireLib = function(module){
+        return br(module);
       };
     }
 

--- a/lib/script.js
+++ b/lib/script.js
@@ -43,6 +43,18 @@ Script.prototype.run = function (ctx, domain, fn) {
     domain = undefined;
   }
 
+  if (typeof domain === 'object') {
+      domain.process = function() { // access process via process()
+        return process;
+      };
+      domain.require = function(module) { // expose require function
+        return require(module);
+      };
+      domain.context = function() { // access Context via context()
+        return ctx;
+      };
+    }
+
   var req = ctx.req
     , session = ctx.session
     , waitingForCallback = false

--- a/lib/script.js
+++ b/lib/script.js
@@ -3,6 +3,8 @@ var _ = require('underscore')._
   , fs = require('fs')
   , bluebird = require('bluebird')
   , br = require("base-require")
+  , path = require('path')
+  , join = path.join
   , util = require('util');
 
 /**
@@ -55,6 +57,7 @@ Script.prototype.run = function (ctx, domain, fn) {
         return ctx;
       };
       domain.requireLib = function(module){
+        br._setRootDir(path.resolve(join(__dirname, '../../../')));
         return br(module);
       };
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "index",
   "dependencies": {
     "async": "^0.9.0",
+    "base-require": "^1.0.0",
     "bluebird": "^2.9.26",
     "commander": "^2.2.0",
     "cookies": "^0.5.0",


### PR DESCRIPTION
So I've been having this issue where I couldn't require modules from a project whenever I was running my own server. I added a couple of features where you can do `var module = require('name_of_the_module')` inside the app (basically I added dpd-event-extension to work natively with deployd) and I added an extra where you can do `var myCustomModule = requireLib('lib/test.js')` so you can add custom modules.

Hope you like it and if you have another thing in mind just feel free to reject this PR