### PR TITLE
Prevent server from crashing if username doesn't exist

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -294,7 +294,9 @@ UserCollection.prototype.handleLogin = function (ctx) {
  * @return {string}      The hash.
  */
 UserCollection.prototype.getUserAndPasswordHash = function(user) {
-  return crypto.createHash('md5').update(user.username + user.password).digest('hex');
+  if(user && user.username && user.password){
+    return crypto.createHash('md5').update(user.username + user.password).digest('hex');
+  }
 };
 
 /**


### PR DESCRIPTION
I had some problems where if the user had been deleted and the session token was still sent, the server would crash. This fixes that problem.