### PR TITLE
prevent crash on invalid user for session

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -112,7 +112,7 @@ UserCollection.prototype.handle = function (ctx) {
             return ctx.done({statusCode: 500, message: "Error retrieving user for verification"});
           }
 
-          var userHash = uc.getUserAndPasswordHash(user);
+          var userHash = user ? uc.getUserAndPasswordHash(user):null;
 
           // verify that the username and password haven't changed since this session was created
           if (ctx.session.data.userhash === userHash) {


### PR DESCRIPTION
If a user was deleted manually, a GET for the logged-in user would crash the process. This simple fix puts the hash generation syntax in line with other requests in this file (`null` if !user).