### PR TITLE
fix(session): use update for updating sessions, not remove and insert

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -312,22 +312,22 @@ Session.prototype.set = function(object) {
 Session.prototype.save = function(fn) {
   var session = this
     , data = _.clone(this.data)
-    , needsQueueBind = false;
-  var sid = null ;
+    , anonymous = false
+    , sid = null;
+  
   if (data.anonymous) {
     delete data.anonymous;
     sid = data.id = this.store.createUniqueIdentifier();
-    needsQueueBind = true;
+    anonymous = true;
   } else {
-    sid = data.id ;
+    sid = data.id;
   }
 
   if (typeof data.id !== "string"){
     return fn('Invalid id');
   }
 
-  this.store.remove({id: data.id}, function (err) {
-    if(err) return fn(err);
+  if (anonymous) {
     session.store.insert(data, function (err, res) {
       if (!err) {
         session.data = res;
@@ -338,11 +338,28 @@ Session.prototype.save = function(fn) {
           userSessionIndex[res.uid][session.data.id] = session;
         }
         session.sid = res.id;
-        if (needsQueueBind) session.bindSocketQueue();
+        session.bindSocketQueue();
       }
       fn(err, res);
     });
-  });
+  } else {
+    delete data.id;
+    session.store.update({id: data.id}, data, function (err) {
+      if (!err) {
+        data.id = sid;
+        session.data = data;
+        sessionIndex[sid] = session;
+
+        if (data.uid) {
+          userSessionIndex[data.uid] = userSessionIndex[data.uid] || {};
+          userSessionIndex[data.uid][session.data.id] = session;
+        }
+        session.sid = data.id;
+      }
+      fn(err, data);
+    });
+  }
+  
   return this;
 };
 


### PR DESCRIPTION
Session update is currently implemented with remove and insert. During the update when the session is removed for a moment and then inserted again, a concurrent query can fail finding the session and result as an anonymous query.

It took a while to find the source of the problem, because it’s difficult to test it. It can happen only after every 10 seconds when the "lastActive" timestamp is updated and when you have another query at the same time, which resulted unauthorized response in my case.

This PR fixes the issue so that new sessions are inserted and old sessions are updated as they should, which allows concurrent queries to find the active session and authorize the user.