### PR TITLE
Improve stability of the tests on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
 sudo: false
 services: mongodb
 node_js:
+  - "5.0"
   - "4.2"
   - "4.1"
   - "4.0"

--- a/test/sessions.unit.js
+++ b/test/sessions.unit.js
@@ -134,7 +134,7 @@ describe('Session', function() {
 
 
 	it('should make sockets available even before they exist', function(done) {
-		this.timeout(100);
+		this.timeout(400);
 
 		var sockets = new EventEmitter()
 			,	fauxSocket = new EventEmitter()


### PR DESCRIPTION
## Work in progress  
The goal of this PR is to increase the stability of the tests on circleci. Currently, it's failing too often because the timeout is too low for some tests.

**Changes**:   
- increate timeout of `it('should make sockets available even before they exist'`
