### PR TITLE
Chore: Upgrade Socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "semver": "^4.3.3",
     "send": "^0.12.2",
     "shelljs": "^0.5.3",
-    "socket.io": "^1.3.6",
+    "socket.io": "^1.3.7",
     "step": "^0.0.5",
     "underscore": "^1.7.0",
     "validation": "*",


### PR DESCRIPTION
@ericfong 
The current version of socket.io is insecured (https://www.bithound.io/github/deployd/deployd/master/dependencies/npm#filter-priority-dep)
We need to upgrade to 1.3.7.
Please, review and eventually rebase.