### PR TITLE
feat(http): custom CORS request/response headers

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -17,8 +17,8 @@ exports.setup = function(options, req, res, next) {
   } else {
     corsOpts.supportsCredentials = false;
   }
-  corsOpts.responseHeaders = corser.simpleResponseHeaders.concat(["X-Session-Token", "X-Session-Invalidated"]);
-  corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]);
+  corsOpts.responseHeaders = corser.simpleResponseHeaders.concat(["X-Session-Token", "X-Session-Invalidated"]).concat(options.allowedResponseHeaders || {});
+  corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]).concat(options.allowedRequestHeaders || {});;
   if (options.allowCorsRootRequests) {
     corsOpts.requestHeaders.push("dpd-ssh-key");
   }

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -17,8 +17,8 @@ exports.setup = function(options, req, res, next) {
   } else {
     corsOpts.supportsCredentials = false;
   }
-  corsOpts.responseHeaders = corser.simpleResponseHeaders.concat(["X-Session-Token", "X-Session-Invalidated"]).concat(options.allowedResponseHeaders || {});
-  corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]).concat(options.allowedRequestHeaders || {});;
+  corsOpts.responseHeaders = corser.simpleResponseHeaders.concat(["X-Session-Token", "X-Session-Invalidated"]).concat(options.allowedResponseHeaders || []);
+  corsOpts.requestHeaders = corser.simpleRequestHeaders.concat(["X-Requested-With", "Authorization"]).concat(options.allowedRequestHeaders || []);
   if (options.allowCorsRootRequests) {
     corsOpts.requestHeaders.push("dpd-ssh-key");
   }


### PR DESCRIPTION
Allow specifying extra headers that should be allowed through CORS:

Example usage:

```javascript
var server = deployd({
  port: process.env.PORT || 1337,
  env: 'production',
  origins: [
    "http://localhost:5000",
  ],
  allowedResponseHeaders: ['ETag'],
  allowedRequestHeaders: ['If-None-Match'],
  db: {
    connectionString: process.env.MONGO_URI
  }
});
```