### PR TITLE
Added Query Key for Mobile compatibility

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -141,12 +141,12 @@ var parseBody = exports.parseBody = function(req, res, mime, callback) {
   });
 };
 
+
 var parseQuery = exports.parseQuery = function(url) {
   var q = url.substr(url.indexOf('?') + 1);
-
   if(q) q = decodeURIComponent(q);
-
-  if(q[0] === '{' && q[q.length - 1] === '}') {
+  if((q.startsWith('mongoq={') || q[0] ==='{') && q[q.length - 1] === '}') {
+    q=q.startsWith('mongoq={') ? q.substring(7, q.length): q;
     return JSON.parse(q);
   } else {
     return parseNumbersInObject(qs.parse(parseUrl(url).query));

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -144,14 +144,21 @@ var parseBody = exports.parseBody = function(req, res, mime, callback) {
 
 var parseQuery = exports.parseQuery = function(url) {
   var q = url.substr(url.indexOf('?') + 1);
+
   if(q) q = decodeURIComponent(q);
-  if((q.startsWith('mongoq={') || q[0] ==='{') && q[q.length - 1] === '}') {
-    q=q.startsWith('mongoq={') ? q.substring(7, q.length): q;
+
+  if(q[0] === '{' && q[q.length - 1] === '}') {
     return JSON.parse(q);
   } else {
-    return parseNumbersInObject(qs.parse(parseUrl(url).query));
+    var parsedQuery = qs.parse(parseUrl(url).query);
+    if (parsedQuery._jsonquery) {
+      return JSON.parse(parsedQuery._jsonquery);
+    }
+
+    return parseNumbersInObject(parsedQuery);
   }
 };
+
 
 /*!
  * Redirects to the given url.
@@ -191,10 +198,3 @@ var parseNumbersInObject = function( obj ){
   }
   return ret;
 };
-
-if (typeof String.prototype.startsWith != 'function') {
-  String.prototype.startsWith = function (str){
-    return this.indexOf(str) === 0 ? str :"" ;
-  };
-
-}

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -191,3 +191,10 @@ var parseNumbersInObject = function( obj ){
   }
   return ret;
 };
+
+if (typeof String.prototype.startsWith != 'function') {
+  String.prototype.startsWith = function (str){
+    return this.indexOf(str) === 0 ? str :"" ;
+  };
+
+}


### PR DESCRIPTION
With this commit you can send advanced queries with “mongoq” key for
mobile url compatibility also this changes has backward compatibility.

example usage
/todos?mongoq={"category": "pets"}