### PR TITLE
Updated Loader to support sub modules

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
   , debug = require('debug')('type-loader')
-  , domain = require('domain');
+  , domain = require('domain')
+  , _=require("underscore");
 
 module.exports = function loadTypes(basepath, fn) {
   var types = {}
@@ -28,6 +29,14 @@ module.exports = function loadTypes(basepath, fn) {
             debug('is a resource ', customResource && customResource.name);
             types[customResource.name] = customResource;
           }
+            if(customResource instanceof Array)
+            {
+                _.each(customResource,function(resource){
+                    debug('is a resource ', resource && resource.name);
+                    types[resource.name] = resource;
+
+                });
+            }
         } catch(e) {
           console.error();
           console.error("Error loading module node_modules/" + file);


### PR DESCRIPTION
This will let us use multiple modules in same package 
just use in index.js 

``` javascript
 var module1 = require("module1"),
     module2 = require("module2");
 module.exports=[module1,module2];
```
