### PR TITLE
Encode hash symbol inside the query URI

### DIFF
--- a/clib/dpd.js
+++ b/clib/dpd.js
@@ -80,7 +80,7 @@
 
   function encodeIfComplex(query) {
     if (isComplex(query)) {
-      return encodeURI(JSON.stringify(query));
+      return encodeURIComponent(JSON.stringify(query));
     } else if (query) {
       return createQueryString(query);
     }


### PR DESCRIPTION
This fixes a bug for queries containing a hash symbol.
Browsers do not replace the `#` symbol when encoding URIs therefore making the end of the query disappear from the request (the browser interprets it as a regular URI hash which doesn't get sent to the server).

It should be noted that there is no error when a broken query is received by the server (i.e. a query split in two will not trigger any error and can even return some results).