### PR TITLE
fix(server): disable resource type loader error

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -29,11 +29,13 @@ module.exports = function loadTypes(basepath, fn) {
             types[customResource.name] = customResource;
           }
         } catch(e) {
+          /*
           console.error();
           console.error("Error loading module node_modules/" + file);
           console.error(e.stack || e);
           if(process.send) process.send({moduleError: e || true});
           process.exit(1);
+          */
         }
 
         if(remaining === 0) {


### PR DESCRIPTION
The deployd server cannot run if any package listed in `package.json` cannot be `require()`d, which happens for some packages which are not meant to ever be `require()`d like `babel-runtime`. Any error due to a missing resource type will be reported when used, so it is not necessary to force-quit here.

I'm not completely happy with disabling error checks but the check makes the server completely unusable in this case.