### PR TITLE
fix(repl): update outdated property name

### DIFF
--- a/lib/client/repl.js
+++ b/lib/client/repl.js
@@ -51,7 +51,7 @@ var commands = {
 
 	resources: function () {
 		server.resources && server.resources.forEach(function (r) {
-			if(r.settings.type) console.log('\t' + r.settings.path, '(' + r.settings.type + ')');
+			if(r.config.type) console.log('\t' + r.path, '(' + r.config.type + ')');
 		});
 	},
 


### PR DESCRIPTION
The `resources` command in the REPL didn't work because `r.settings` did not exist and `r.config` should be used instead.

Fixes #680