### PR TITLE
perf(script): memoize dynamic function

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -20,7 +20,7 @@ Script.prototype.runWithContext = function (context) {
   functionArgs.splice(functionArgs.indexOf('this'), 1);
 
   functionArgs.push(this.scriptSourceCode);
-  var func = Function.apply(null, functionArgs);
+  var func = this.getFunction(functionArgs);
 
   // pass our arguments from the sandbox to the function
   var args = [];
@@ -29,6 +29,10 @@ Script.prototype.runWithContext = function (context) {
   });
   return func.apply(context._this || {}, args);
 };
+
+Script.prototype.getFunction = _.memoize(function(functionArgs) {
+  return Function.apply(null, functionArgs);
+});
 
 /**
  * Run the current script in the given sandbox. An optional domain may be provided to extend the sandbox exposed to the script.


### PR DESCRIPTION
This improves performance when there are a lot of requests per second.

Tested with 1000 requests per second:

`loadtest --rps 1000 -k -t 20 http://localhost:1337/test`

Where `test` is a simple Event Resource script that doesn't do any database interaction, and just returns a simple response.

Before:
```
Percentage of the requests served within a certain time
50%      35 ms
90%      188 ms
95%      214 ms
99%      259 ms
100%      463 ms (longest request)
```

After:
```
Percentage of the requests served within a certain time
50%      8 ms
90%      33 ms
95%      39 ms
99%      48 ms
100%      66 ms (longest request)
```