### PR TITLE
correct extreme uses of hide() and protect()

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -568,7 +568,7 @@ Collection.prototype.save = function (ctx, fn) {
 
         delete item.id;
         if ((_.keys(prev).length > 0) && (_.keys(item).length === 0)) {
-          return done(null, {id: id});
+          return done(null, {});
         }
       	
         store.update({id: query.id}, item, function (err) {

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -567,6 +567,10 @@ Collection.prototype.save = function (ctx, fn) {
         }
 
         delete item.id;
+        if ((_.keys(prev).length > 0) && (_.keys(item).length == 0)) {
+          return done(null, {id: id});
+        }
+      	
         store.update({id: query.id}, item, function (err) {
           if(err) return done(err);
           item.id = id;

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -567,7 +567,7 @@ Collection.prototype.save = function (ctx, fn) {
         }
 
         delete item.id;
-        if ((_.keys(prev).length > 0) && (_.keys(item).length == 0)) {
+        if ((_.keys(prev).length > 0) && (_.keys(item).length === 0)) {
           return done(null, {id: id});
         }
       	


### PR DESCRIPTION
this addresses the problem of #254 where, if you hide or protect all fields of an object during a PUT operation, all the data of the record will be deleted.