### PR TITLE
MongoDB 3.2 is more strict on data type of .skip .limit - ensure that it is an integer

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -597,8 +597,8 @@ function stripOptions(query) {
   var options = {};
   if(!query) return options;
   // performance
-  if(query.$limit) options.limit = query.$limit;
-  if(query.$skip) options.skip = query.$skip;
+  if(query.$limit) options.limit = parseInt(query.$limit);
+  if(query.$skip) options.skip = parseInt(query.$skip);
   if(query.$sort || query.$orderby) options.sort = query.$sort || query.$orderby;
   delete query.$limit;
   delete query.$skip;

--- a/test/db.unit.js
+++ b/test/db.unit.js
@@ -69,6 +69,31 @@ describe('store', function(){
       });
     });
 
+    describe('.find({$limit: "n"}, fn)', function() {
+      it('should limit the result using integer value', function(done) {
+        store.insert([{i:1},{i:2},{i:3},{i:4},{i:5},{i:6},{i:7},{i:8},{i:9}], function () {
+          store.find({$limit: "2"}, function (err, result) {
+            expect(result).to.exist;
+            expect(result).to.have.length(2);
+            done(err);
+          });
+        });
+      });
+    });
+
+    describe('.find({$skip: n}, fn)', function() {
+      it('should skip the result using integer value', function(done) {
+        store.insert([{i:1},{i:2},{i:33333},{i:4},{i:5},{i:6},{i:7},{i:8},{i:9}], function () {
+          store.find({$skip: "2"}, function (err, result) {
+            expect(result).to.exist;
+            expect(result[0].i).to.equal(33333);
+            done(err);
+          });
+        });
+      });
+    });
+
+
     describe('.count({}, fn)', function() {
       it('should count the results', function(done) {
         store.insert([{i:1},{i:2},{i:33333},{i:4},{i:5},{i:6},{i:7},{i:8},{i:9}], function () {


### PR DESCRIPTION
mongo 3.2 is more strict on $skip and $limit