### PR TITLE
You can add a dpdIgnore property inside the package.json file as an a…

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -71,7 +71,10 @@ module.exports = function loadTypes(basepath, fn) {
         process.exit(1);
       }
       if (packageJson && packageJson.dependencies) {
-        var dependencies = packageJson.dependencies;
+        var dependencies = packageJson.dpdInclude && packageJson.dpdInclude.length ? packageJson.dpdInclude.reduce(function(prev, curr) {
+          prev[curr] = packageJson.dependencies[curr];
+          return prev;
+        }, {}) : packageJson.dependencies;
         var dpdIgnore = packageJson.dpdIgnore || [];
         debug('Loading these dependencies from package.json', dependencies);
         remaining = 0;

--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -72,10 +72,11 @@ module.exports = function loadTypes(basepath, fn) {
       }
       if (packageJson && packageJson.dependencies) {
         var dependencies = packageJson.dependencies;
+        var dpdIgnore = packageJson.dpdIgnore || [];
         debug('Loading these dependencies from package.json', dependencies);
         remaining = 0;
         for (var dependency in dependencies) {
-          loadCustomResources(dependency);
+          if(dpdIgnore.indexOf(dependency) === -1) loadCustomResources(dependency);
         }
       }
     } else {

--- a/test/typeloader.unit.js
+++ b/test/typeloader.unit.js
@@ -83,10 +83,6 @@ describe('type-loader', function(){
     });
 
     it('should load the default resources and the customResources based on package.json (w dpdInclude)', function(done) {
-      if (fs.existsSync(basepath)) {
-        sh.rm('-rf', basepath);
-      }
-
       createPackageJson({include: true});
       TypeLoader(basepath, function(resources, customResources) {
         expect(customResources).to.not.be.empty;

--- a/test/typeloader.unit.js
+++ b/test/typeloader.unit.js
@@ -14,7 +14,7 @@ describe('type-loader', function(){
   });
 
   describe('.loadTypes(basepath, fn)', function() {
-    var createPackageJson = function() {
+    var createPackageJson = function(opts) {
       if (fs.existsSync(basepath)) {
         sh.rm('-rf', basepath);
       }
@@ -22,9 +22,16 @@ describe('type-loader', function(){
       sh.cp('./lib/resource.js', basepath + '/resource.js');
       sh.cp('./lib/script.js', basepath + '/script.js');
       var pack = {dependencies:
-        {'dpd-fileupload':'^0.0.10', 'dpd-count': '0.0.1'},
-        dpdIgnore: ["dpd-count"]
+        {'dpd-fileupload':'^0.0.10', 'dpd-count': '0.0.1'}
       };
+
+      if(opts.ignore){
+        pack.dpdIgnore = ["dpd-count"];
+      }
+
+      if(opts.include){
+        pack.dpdInclude = ["dpd-count"];
+      }
 
       JSON.stringify(pack).to(path.join(basepath, 'package.json'));
       sh.mkdir('-p', path.join(basepath, 'node_modules/dpd-fileupload'));
@@ -65,12 +72,26 @@ describe('type-loader', function(){
     });
 
 
-    it('should load the default resources and the customResources based on package.json', function(done) {
-      createPackageJson();
+    it('should load the default resources and the customResources based on package.json (w dpdIgnore)', function(done) {
+      createPackageJson({ignore: true});
       TypeLoader(basepath, function(resources, customResources) {
         expect(customResources).to.not.be.empty;
         expect(customResources).to.include.keys('Fileupload');
         expect(customResources).to.not.include.keys('Count');
+        done();
+      });
+    });
+
+    it('should load the default resources and the customResources based on package.json (w dpdInclude)', function(done) {
+      if (fs.existsSync(basepath)) {
+        sh.rm('-rf', basepath);
+      }
+
+      createPackageJson({include: true});
+      TypeLoader(basepath, function(resources, customResources) {
+        expect(customResources).to.not.be.empty;
+        expect(customResources).to.not.include.keys('Fileupload');
+        expect(customResources).to.include.keys('Count');
         done();
       });
     });

--- a/test/typeloader.unit.js
+++ b/test/typeloader.unit.js
@@ -21,7 +21,12 @@ describe('type-loader', function(){
       sh.mkdir('-p', basepath);
       sh.cp('./lib/resource.js', basepath + '/resource.js');
       sh.cp('./lib/script.js', basepath + '/script.js');
-      JSON.stringify({dependencies: {'dpd-fileupload':'^0.0.10'}}).to(path.join(basepath, 'package.json'));
+      var pack = {dependencies:
+        {'dpd-fileupload':'^0.0.10', 'dpd-count': '0.0.1'},
+        dpdIgnore: ["dpd-count"]
+      };
+
+      JSON.stringify(pack).to(path.join(basepath, 'package.json'));
       sh.mkdir('-p', path.join(basepath, 'node_modules/dpd-fileupload'));
       var dpdFileuploadIndexJs = "var Resource   = require('../../resource');\n";
           dpdFileuploadIndexJs += "util = require('util');\n";
@@ -29,13 +34,23 @@ describe('type-loader', function(){
           dpdFileuploadIndexJs += "util.inherits(Fileupload, Resource);\n";
           dpdFileuploadIndexJs += "module.exports = Fileupload;\n";
       dpdFileuploadIndexJs.to(path.join(basepath + '/node_modules/dpd-fileupload', 'index.js'));
+      sh.mkdir('-p', path.join(basepath, 'node_modules/dpd-event'));
+
+      sh.mkdir('-p', path.join(basepath, 'node_modules/dpd-count'));
+      var dpdCountIndexJs = "var Resource   = require('../../resource');\n";
+          dpdCountIndexJs += "util = require('util');\n";
+          dpdCountIndexJs += "function Count() { console.log('type-loader');}\n";
+          dpdCountIndexJs += "util.inherits(Count, Resource);\n";
+          dpdCountIndexJs += "module.exports = Count;\n";
+      dpdCountIndexJs.to(path.join(basepath + '/node_modules/dpd-count', 'index.js'));
+      sh.mkdir('-p', path.join(basepath, 'node_modules/dpd-count'));
+
       this.server = new Server();
     };
 
 
     it('should load the default resources', function(done) {
       TypeLoader(basepath, function(resources, customResources) {
-
         expect(resources).to.not.be.empty;
         expect(resources).to.include.keys('ClientLib');
         expect(resources).to.include.keys('Collection');
@@ -53,9 +68,9 @@ describe('type-loader', function(){
     it('should load the default resources and the customResources based on package.json', function(done) {
       createPackageJson();
       TypeLoader(basepath, function(resources, customResources) {
-
         expect(customResources).to.not.be.empty;
         expect(customResources).to.include.keys('Fileupload');
+        expect(customResources).to.not.include.keys('Count');
         done();
       });
     });


### PR DESCRIPTION
…rray to force ignoring modules in the type-loader. This should fix #717 

Usage:
```
{dependencies: {
   "dpd-fileuploader": "*",
   "dpd-count": "*",
   "angular": "*"
},
  dpdIgnore: ["angular"]
}
```
I thought since #717 and PR #701 need this feature, this would be the best way to implement that.