### PR TITLE
`dpd -d` fails when scanning node_modules directory

### DIFF
--- a/lib/type-loader.js
+++ b/lib/type-loader.js
@@ -29,11 +29,13 @@ module.exports = function loadTypes(basepath, fn) {
             types[customResource.name] = customResource;
           }
         } catch(e) {
-          console.error();
-          console.error("Error loading module node_modules/" + file);
-          console.error(e.stack || e);
-          if(process.send) process.send({moduleError: e || true});
-          process.exit(1);
+          if (e && e.code !== 'MODULE_NOT_FOUND') {
+            console.error();
+            console.error("Error loading module node_modules/" + file);
+            console.error(e.stack || e);
+            if(process.send) process.send({moduleError: e || true});
+            process.exit(1);
+          }
         }
 
         if(remaining === 0) {


### PR DESCRIPTION
I have a similar issue as raised in #380. It seems that this issue was closed automatically when the issuer fixed the issue in his own fork of `deployd` but there was never a PR to fix this upstream.

This PR has that fix but I applied it on the current master.