### PR TITLE
username case-insensitive check

### DIFF
--- a/lib/resources/user-collection.js
+++ b/lib/resources/user-collection.js
@@ -155,7 +155,8 @@ UserCollection.prototype.handle = function (ctx) {
       if(ctx.query.id || ctx.body.id) {
         this.save(ctx, done);
       } else {
-        this.store.first({username: ctx.body.username}, function (err, u) {
+        var usernameRegex = new RegExp(["^", ctx.body.username, "$"].join(""), "i");
+        this.store.first({username: usernameRegex}, function (err, u) {
           if(u) return ctx.done({errors: {username: 'is already in use'}});
           uc.save(ctx, done);
         });


### PR DESCRIPTION
username case-insensitive check ( avoid duplicated users with similar usernames and different case sensitive letters )

i think it's a must to have this check
i.e
1 - user enter his username with first letter uppercase
2- user try to create another user with same username but all lowercase or different letter cases
3 - account will get created, usually users are not used to differentiate between lowercase / uppercase letters in usernames, only in passwords they care most.

hope it's useful pull request 
