### PR TITLE
fix(collection): protect and hide should not modify `this`

### DIFF
--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -492,29 +492,7 @@ Collection.prototype.save = function (ctx, fn) {
     fn(errors || err, item);
   }
 
-  var domain = collection.createDomain(item, errors);
-
-  domain.protectedKeys = [];
-
-  domain.protect = function(property) {
-    if (domain.data.hasOwnProperty(property)) {
-      domain.protectedKeys.push(property);
-      delete domain.data[property];
-    }
-  };
-
-  domain.changed =  function (property) {
-    if(domain.data.hasOwnProperty(property)) {
-      if(domain.previous && _.isEqual(domain.previous[property], domain.data[property])) {
-        return false;
-      }
-
-      return true;
-    }
-    return false;
-  };
-
-  domain.previous = {};
+  var domain = collection.createDomain(item, errors, true);
 
   function put() {
     var id = query.id
@@ -547,6 +525,9 @@ Collection.prototype.save = function (ctx, fn) {
       domain.data = item;
       domain.previous = prev;
 
+      // disallow changes to id
+      domain.protect('id');
+
       collection.execCommands('update', item, commands);
 
       var errs = collection.validate(item);
@@ -570,14 +551,19 @@ Collection.prototype.save = function (ctx, fn) {
           return done(err || errors);
         }
 
-        delete item.id;
-        if ((_.keys(prev).length > 0) && (_.keys(item).length === 0)) {
-          return done(null, {});
+        var itemWithoutProtectedKeys = _.clone(item);
+        domain.protectedKeys.forEach(function (key) {
+          if (key && itemWithoutProtectedKeys.hasOwnProperty(key)) delete itemWithoutProtectedKeys[key];
+        });
+
+        if ((Object.keys(prev).length > 0) && (Object.keys(itemWithoutProtectedKeys).length === 0)) {
+          // if we're protecting everything just return the item, nothing will actually be saved
+          return done(null, item);
         }
-      	
-        store.update({id: query.id}, item, function (err) {
+      
+        store.update({id: query.id}, itemWithoutProtectedKeys, function (err) {
           if(err) return done(err);
-          item.id = id;
+
           collection.doAfterCommitEvent('PUT', ctx, item, prev, domain.protectedKeys);
           done(null, item);
         });
@@ -652,7 +638,7 @@ Collection.prototype.save = function (ctx, fn) {
   }
 };
 
-Collection.prototype.createDomain = function(data, errors) {
+Collection.prototype.createDomain = function(data, errors, persistable) {
   var collection = this;
 
   var hasErrors = false;
@@ -673,13 +659,65 @@ Collection.prototype.createDomain = function(data, errors) {
     hasErrors: function() {
       return hasErrors;
     },
-    hide: function(property) {
-      delete domain.data[property];
+    hide: function(property, toggle) {
+      if (typeof toggle === 'undefined') { toggle = true; }
+      if (domain.data.hasOwnProperty(property)) {
+        Object.defineProperty(domain.data, property, {
+          value: domain.data[property],
+          enumerable: toggle ? false : true
+        });
+      }
+    },
+    unhide: function(property) {
+      domain.hide(property, false);
     },
     'this': data,
     data: data
   };
   collection.addDomainAdditions(domain);
+
+  // additional domain additions for when the domain is used to persist data (such as POST/PUT)
+  if (persistable) {
+    domain.previous = {};
+
+    domain.protectedKeys = [];
+    domain.protect = function(property, toggle) {
+      if (typeof toggle === 'undefined') { toggle = true; }
+
+      if (domain.data.hasOwnProperty(property) && toggle && domain.protectedKeys.indexOf(property) === -1) {
+        domain.protectedKeys.push(property);
+        Object.defineProperty(domain.data, property, {
+          get: function() {
+            return domain.previous[property];
+          },
+          set: function() {
+            throw new TypeError("Cannot modify protected property '" + property + "'");
+          },
+          configurable: true
+        });
+      } else if (domain.data.hasOwnProperty(property) && !toggle && domain.protectedKeys.indexOf(property) !== -1) {
+        domain.protectedKeys.splice(domain.protectedKeys.indexOf(property), 1);
+        var previousValue = domain.data[property];
+        delete domain.data[property];
+        domain.data[property] = previousValue;
+      }
+    };
+
+    domain.unprotect = function(property) {
+      domain.protect(property, false);
+    };
+
+    domain.changed =  function (property) {
+      if(domain.data.hasOwnProperty(property)) {
+        if(domain.previous && _.isEqual(domain.previous[property], domain.data[property])) {
+          return false;
+        }
+
+        return true;
+      }
+      return false;
+    };
+  }
   return domain;
 };
 
@@ -695,16 +733,11 @@ Collection.prototype.addDomainAdditions = function(domain) {
   });
 };
 
-Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous, protectedKeys) {
+Collection.prototype.doAfterCommitEvent = function(method, ctx, data, previous) {
   var collection = this;
   if (collection.shouldRunEvent(collection.events.AfterCommit, ctx)) {
     data = _.clone(data);
-    if (protectedKeys && protectedKeys.length > 0 && previous) {
-      // add back whatever fields were protected, because they are removed from data
-      protectedKeys.forEach(function (key) {
-        data[key] = previous[key];
-      });
-    }
+   
     var domain = {data: data, 'this': data, method: method, previous: previous};
     collection.addDomainAdditions(domain);
     collection.events.AfterCommit.run(ctx, domain, function (err) {

--- a/lib/resources/collection/index.js
+++ b/lib/resources/collection/index.js
@@ -551,20 +551,17 @@ Collection.prototype.save = function (ctx, fn) {
           return done(err || errors);
         }
 
-        var itemWithoutProtectedKeys = _.clone(item);
-        domain.protectedKeys.forEach(function (key) {
-          if (key && itemWithoutProtectedKeys.hasOwnProperty(key)) delete itemWithoutProtectedKeys[key];
-        });
+        var updateObject = domain.getUpdateObject();
 
-        if ((Object.keys(prev).length > 0) && (Object.keys(itemWithoutProtectedKeys).length === 0)) {
+        if ((Object.keys(prev).length > 0) && (Object.keys(updateObject).length === 0)) {
           // if we're protecting everything just return the item, nothing will actually be saved
           return done(null, item);
         }
       
-        store.update({id: query.id}, itemWithoutProtectedKeys, function (err) {
+        store.update({id: query.id}, updateObject, function (err) {
           if(err) return done(err);
 
-          collection.doAfterCommitEvent('PUT', ctx, item, prev, domain.protectedKeys);
+          collection.doAfterCommitEvent('PUT', ctx, item, prev);
           done(null, item);
         });
       }
@@ -588,9 +585,11 @@ Collection.prototype.save = function (ctx, fn) {
 
     // generate id before event listener
     item.id = store.createUniqueIdentifier();
-
+    
     function commit(){
-      store.insert(item, function(err, data) {
+      var updateObject = domain.getUpdateObject();
+
+      store.insert(updateObject, function(err, data) {
         if (err) return done(err);
         collection.doAfterCommitEvent('POST', ctx, item);
         done(null, data);
@@ -643,6 +642,7 @@ Collection.prototype.createDomain = function(data, errors, persistable) {
 
   var hasErrors = false;
   var domain = {
+    hiddenProperties: [],
     error: function(key, val) {
       debug('error %s %s', key, val);
       errors[key] = val || true;
@@ -661,7 +661,14 @@ Collection.prototype.createDomain = function(data, errors, persistable) {
     },
     hide: function(property, toggle) {
       if (typeof toggle === 'undefined') { toggle = true; }
+
       if (domain.data.hasOwnProperty(property)) {
+        if (toggle && domain.hiddenProperties.indexOf(property) === -1) {
+          domain.hiddenProperties.push(property);
+        } else if (domain.hiddenProperties.indexOf(property) !== -1) {
+          domain.hiddenProperties.splice(domain.hiddenProperties.indexOf(property), 1);
+        }
+
         Object.defineProperty(domain.data, property, {
           value: domain.data[property],
           enumerable: toggle ? false : true
@@ -680,12 +687,12 @@ Collection.prototype.createDomain = function(data, errors, persistable) {
   if (persistable) {
     domain.previous = {};
 
-    domain.protectedKeys = [];
+    domain.protectedProperties = [];
     domain.protect = function(property, toggle) {
       if (typeof toggle === 'undefined') { toggle = true; }
 
-      if (domain.data.hasOwnProperty(property) && toggle && domain.protectedKeys.indexOf(property) === -1) {
-        domain.protectedKeys.push(property);
+      if (domain.data.hasOwnProperty(property) && toggle && domain.protectedProperties.indexOf(property) === -1) {
+        domain.protectedProperties.push(property);
         Object.defineProperty(domain.data, property, {
           get: function() {
             return domain.previous[property];
@@ -695,8 +702,8 @@ Collection.prototype.createDomain = function(data, errors, persistable) {
           },
           configurable: true
         });
-      } else if (domain.data.hasOwnProperty(property) && !toggle && domain.protectedKeys.indexOf(property) !== -1) {
-        domain.protectedKeys.splice(domain.protectedKeys.indexOf(property), 1);
+      } else if (domain.data.hasOwnProperty(property) && !toggle && domain.protectedProperties.indexOf(property) !== -1) {
+        domain.protectedProperties.splice(domain.protectedProperties.indexOf(property), 1);
         var previousValue = domain.data[property];
         delete domain.data[property];
         domain.data[property] = previousValue;
@@ -707,7 +714,7 @@ Collection.prototype.createDomain = function(data, errors, persistable) {
       domain.protect(property, false);
     };
 
-    domain.changed =  function (property) {
+    domain.changed = function (property) {
       if(domain.data.hasOwnProperty(property)) {
         if(domain.previous && _.isEqual(domain.previous[property], domain.data[property])) {
           return false;
@@ -716,6 +723,21 @@ Collection.prototype.createDomain = function(data, errors, persistable) {
         return true;
       }
       return false;
+    };
+
+    domain.getUpdateObject = function() {
+      var result = {};
+
+      // this is needed to ensure that hidden (nonenumerable) properties are copied to the update object
+      Object.getOwnPropertyNames(domain.data).forEach(function (key) {
+        result[key] = domain.data[key];
+      });
+        
+      domain.protectedProperties.forEach(function (key) {
+        if (key && result.hasOwnProperty(key)) delete result[key];
+      });
+
+      return result;
     };
   }
   return domain;

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -527,6 +527,7 @@ describe('Collection', function () {
           expect(result.title).to.not.exist;
           dpd.todos.get(result.id, next);
         }).chain(function(next, result, err) {
+          expect(result.done).to.equal(true);
           expect(result.error_message_ok).to.equal(true);
           expect(result.error_id_ok).to.equal(true);
           expect(result.message).to.equal("x");

--- a/test-app/public/test/collection.test.js
+++ b/test-app/public/test/collection.test.js
@@ -118,6 +118,22 @@ describe('Collection', function () {
           });
         });
       });
+
+      it('should respond to the changed event (in AfterCommit) on put and have access to previous data', function(done) {
+        dpd.todos.post({title: 'changed - create', message: 'protected'}, function(item) {
+          dpd.socketReady(function() {
+            dpd.todos.once('changed', function(data) {
+              expect(data.previous.title).to.equal('changed - create');
+              expect(data.previous.message).to.equal('protected');
+              expect(data.current.title).to.equal('changed - updated');
+              expect(data.current.message).to.equal('protected');
+              done();
+            });
+
+            dpd.todos.put(item.id, {title: 'changed - updated', message: 'should not change'});
+          });
+        });
+      });
     });
 
     describe('.post({title: \'faux\'}, fn)', function() {
@@ -378,6 +394,19 @@ describe('Collection', function () {
       });
     });
 
+    describe('.get({hideTitle: true}, fn)', function() {
+      it('should hide property from response', function(done) {
+        dpd.todos.post({title: 'foobar'}, function () {
+          dpd.todos.get({hideTitle: true}, function (todos, err) {
+            expect(todos.length).to.equal(1);
+            expect(todos[0].title).to.not.exist;
+            done(err);
+          });
+        });
+      });
+    });
+
+
     describe('.get({arbitrary: true}, fn)', function() {
       it('should allow arbitrary query parameters', function(done) {
         dpd.todos.post({title: 'foobar'}, function () {
@@ -482,6 +511,25 @@ describe('Collection', function () {
         }).chain(function(next, result) {
           expect(result.message).to.equal("xx");
           expect(result.done).to.equal(true);
+          done();
+        });
+      });
+    });
+
+    describe('.put(id, fn)', function() {
+      it('should be able to read properties after using protect(...) in On Put', function(done) {
+        chain(function(next) {
+          dpd.todos.post({title: '$PROTECT_TEST', message: "x"}, next);
+        }).chain(function(next, result, err) {
+          dpd.todos.put(result.id, {message: "y"}, next);
+        }).chain(function(next, result, err) {
+          expect(result.message).to.equal("x");
+          expect(result.title).to.not.exist;
+          dpd.todos.get(result.id, next);
+        }).chain(function(next, result, err) {
+          expect(result.error_message_ok).to.equal(true);
+          expect(result.error_id_ok).to.equal(true);
+          expect(result.message).to.equal("x");
           done();
         });
       });

--- a/test-app/resources/todos/aftercommit.js
+++ b/test-app/resources/todos/aftercommit.js
@@ -1,1 +1,1 @@
-emit('todos:changed');
+emit('todos:changed', {previous: previous, current: this});

--- a/test-app/resources/todos/get.js
+++ b/test-app/resources/todos/get.js
@@ -25,3 +25,7 @@ if (query.numberGet) {
 if (query.arbitrary) {
     this.custom = 'arbitrary';
 }
+
+if (query.hideTitle) {
+    hide('title');
+}

--- a/test-app/resources/todos/put.js
+++ b/test-app/resources/todos/put.js
@@ -14,7 +14,6 @@ if (this.title === "$PROTECT_TEST") {
   protect('message');
   
   if (this.message !== 'x') error('message', 'should be x again after protect');
-  console.log(this.message);
 
   try {
     // this should throw an error

--- a/test-app/resources/todos/put.js
+++ b/test-app/resources/todos/put.js
@@ -34,6 +34,10 @@ if (this.title === "$PROTECT_TEST") {
   }
 
   hide('title'); // check that hide also works in put
+
+  // keep this to ensure that even if the field is hidden it is still updated properly
+  this.done = true;
+  hide('done');
 }
 
 if (previous.message == "protected") {

--- a/test-app/resources/todos/put.js
+++ b/test-app/resources/todos/put.js
@@ -8,3 +8,35 @@ if (this.title === "$PUT_TEST") {
 if (this.message == "notvalidput") {
     error('message', "message should not be notvalidput");
 }
+
+if (this.title === "$PROTECT_TEST") {
+  if (this.message !== 'y') error('message', 'should be new value of y before protect');
+  protect('message');
+  
+  if (this.message !== 'x') error('message', 'should be x again after protect');
+  console.log(this.message);
+
+  try {
+    // this should throw an error
+    this.message = 'z';
+  } catch (err) {
+    if (err.message == "Cannot modify protected property 'message'") {
+      this.error_message_ok = true;
+    }
+  }
+
+  try {
+    // this should throw an error
+    this.id = 'hello';
+  } catch (err) {
+    if (err.message == "Cannot modify protected property 'id'") {
+      this.error_id_ok = true;
+    }
+  }
+
+  hide('title'); // check that hide also works in put
+}
+
+if (previous.message == "protected") {
+  protect('message');
+}

--- a/test/util.unit.js
+++ b/test/util.unit.js
@@ -39,7 +39,6 @@ describe('.getBody', function(){
     var res = this.res;
 
     http.getBody(req, function(buffer) {
-      console.error('STREAM', buffer, typeof buffer);
       expect(buffer).to.exist;
       expect(buffer).to.eql(obj);
       done();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Calling `protect('property')` in an event script would delete the property from the `this` object, so `this.property` would immediately become undefined after a protect call.
Same with hide.

For example:

```
On Put:

// this.owner has a value
protect(this.owner);

// this.owner was undefined here (bug):
if (this.owner == me.id) { ... }
```

Additionally, calls to `protect()` in PUT would supress those properties from being returned in the response JSON, which was a bug. The proper way is to use `hide()` for such purposes.

There is a potentially breaking change for users of the library that were relying on the broken behavior of `protect()` to hide fields from being returned via `PUT`. However, that was never documented, so it should be an infrequent use case.

## Motivation and Context

With this change, if after protecting a property, some other code attempts to update it, a `TypeError` error will be thrown. But this should be expected.

## How Has This Been Tested?
The PR includes several new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

