### PR TITLE
fix(internal-client): add req.resume()

### DIFF
--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -80,6 +80,7 @@ exports.build = function(server, session, stack, ctx) {
           , headers: (ctx && ctx.req) ? (ctx.req.headers || {}) : {}
           , connection: (ctx && ctx.req) ? (ctx.req.connection || {}) : {}
           , on: function() {}
+          , resume: function() {}
         };
 
         var callback = function(data, error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The doh package calls req.resume() when an error occurs, but when using an internal dpd client call, the req is mocked. It previously didn't have a .resume() method, resulting in hard crashes under certain conditions when an error occured in a subsequent client script.

See https://github.com/ritch/doh/issues/1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

