### PR TITLE
fix: add socketIo check when using deployd.attach without server.options.socketIo

### DIFF
--- a/lib/attach.js
+++ b/lib/attach.js
@@ -71,7 +71,7 @@ function attach(httpServer, options) {
       'log level': 0
     }, (server.options.socketIo && server.options.socketIo.options) || {}));
     server.sockets = socketIo.sockets;
-    if (server.options.socketIo.adapter) {
+    if (server.options.socketIo && server.options.socketIo.adapter) {
       socketIo.adapter(server.options.socketIo.adapter);
     }
   }


### PR DESCRIPTION
When using deployd.attach(server, settings.options); and server.options do not have socketIo the access to socket.Io.adapter causes a crash.

## Description
This PR https://github.com/deployd/deployd/pull/777 does the main work but there was a check forgotten that when the given server.options do not have socketIo the access to socketIo.adapter causes a crash.