### PR TITLE
Do not overwrite pre-existing res.headers

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -74,7 +74,12 @@ Context.prototype.end = function() {
 
 Context.prototype.done = function(err, res) {
   var body = res
-    , type = 'application/json';
+    , type = 'application/json'
+    , defaultHeaders = {
+      "Cache-Control":"no-cache, no-store, must-revalidate",
+      "Pragma":"no-cache",
+      "Expires":"0"
+    };
 
   // default response
   var status = this.res.statusCode = this.res.statusCode || 200;
@@ -92,19 +97,20 @@ Context.prototype.done = function(err, res) {
     }
 
     try {
-      this.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-      this.res.setHeader("Pragma", "no-cache");
-      this.res.setHeader("Expires", "0");
+      if (this.res.getHeader) {
+        for (var defaultHeader in defaultHeaders) {
+          if(defaultHeaders.hasOwnProperty(defaultHeader)) {
+            if (!this.res.getHeader(defaultHeader))
+              this.res.setHeader(defaultHeader, defaultHeaders[defaultHeader]);
+          }
+        }
+      }
       if(status != 204 && status != 304) {
         if(body) {
           this.res.setHeader('Content-Length', Buffer.isBuffer(body)
                ? body.length
                : Buffer.byteLength(body));
         }
-        if(this.res.getHeader) {
-          if (!this.res.getHeader('content-type')) this.res.setHeader('Content-Type', type)
-        }
-        else this.res.setHeader('Content-Type', type);
         this.res.end(body);
       } else {
         this.res.end();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Stop overwriting any pre-existing res.headers when ending the request
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want to implement a solution for writing custom headers in dpd-event; should I want to set Content-Type or another header, the previous solution would overwrite this.

## How Has This Been Tested?
By making the edit and testing that I'm able to overwrite the cache-control header to: "I'm not very good with money or guns" and verifying in postman
Tried `npm test` and resolving modules but blocked at mongo connection troubles 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
