### PR TITLE
fix(internal-resources): namespaced resources could not be moved/renamed into other namespaces

### DIFF
--- a/lib/resources/internal-resources.js
+++ b/lib/resources/internal-resources.js
@@ -157,11 +157,16 @@ InternalResources.prototype.handle = function(ctx, next) {
                 newId && newId !== id) {
               //rename
               if (newId.indexOf('/') === 0) newId = newId.substring(1);
-              fs.rename(path.join(basepath, 'resources', id), path.join(basepath, 'resources', newId), function(err) {
-                if (err) return ctx.done(err);
+              try {
+                shell.mkdir('-p', path.join(basepath, 'resources', newId));
+                shell.mv(path.join(basepath, 'resources', id, '/*'), path.join(basepath, 'resources', newId, '/'));
+                
+                deleteEmptySubdirs(basepath, id);
                 resource.id = newId;
                 ctx.done(null, resource);
-              });
+              } catch (err) {
+                if (err) return ctx.done(err);
+              }
             } else {
               resource.id = id;
               ctx.done(null, resource);
@@ -266,9 +271,7 @@ InternalResources.prototype.handle = function(ctx, next) {
       var resourcePath = path.join(basepath, 'resources', id);
       try {
         shell.rm(resourcePath + path.sep + '*'); // delete all files in resource directory, but leave subdirectories
-        if (shell.ls('-R', resourcePath).length === 0) {
-          shell.rm('-rf', resourcePath); // delete empty directory
-        }
+        deleteEmptySubdirs(basepath, resourcePath);
         notifyType(id, 'Deleted', null, ctx.server, function(eventError) {
           ctx.done(eventError);
         });
@@ -309,4 +312,22 @@ function notifyType(id, event, config, server, fn) {
   } else {
     fn();
   }
+}
+
+function deleteEmptySubdirs(basepath, id) {
+  // go through a list of potentially leftover directories
+  var idParts = id.split('/');
+  var paths = idParts.map(function(part, index) {
+    return idParts.slice(0, index + 1).join('/');
+  }).filter(function(part) {
+    return part.length > 0 
+  });
+  paths.reverse();
+  
+  // loop through the list and check if they're empty, then delete them
+  paths.forEach(function(pathPart) {
+    if (shell.ls('-R', path.join(basepath, 'resources', pathPart)).length === 0) {
+      shell.rm('-rf', path.join(basepath, 'resources', pathPart)); // delete empty directory
+    }
+  });
 }

--- a/lib/resources/internal-resources.js
+++ b/lib/resources/internal-resources.js
@@ -271,7 +271,12 @@ InternalResources.prototype.handle = function(ctx, next) {
       var resourcePath = path.join(basepath, 'resources', id);
       try {
         shell.rm(resourcePath + path.sep + '*'); // delete all files in resource directory, but leave subdirectories
+        
         deleteEmptySubdirs(basepath, resourcePath);
+        if (shell.ls('-R', resourcePath).length === 0) {
+          shell.rm('-rf', resourcePath); // delete empty directory
+        }
+
         notifyType(id, 'Deleted', null, ctx.server, function(eventError) {
           ctx.done(eventError);
         });
@@ -320,7 +325,7 @@ function deleteEmptySubdirs(basepath, id) {
   var paths = idParts.map(function(part, index) {
     return idParts.slice(0, index + 1).join('/');
   }).filter(function(part) {
-    return part.length > 0 
+    return part.length > 0;
   });
   paths.reverse();
   


### PR DESCRIPTION
Could not rename resources named 'a/b/c' to 'x/y/z'. Would get EPERM errors.