### PR TITLE
fix: don't overwrite http headers with defaults

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -75,6 +75,10 @@ Context.prototype.end = function() {
 Context.prototype.done = function(err, res) {
   var body = res
     , type = 'application/json';
+  
+  // make sure the response hasn't already been sent
+  // might happen if someone calls ctx.res.end() inside an event script
+  if (this.res.finished) return;
 
   // default response
   var status = this.res.statusCode = this.res.statusCode || 200;
@@ -93,7 +97,7 @@ Context.prototype.done = function(err, res) {
 
     try {
       var maybeSetHeader = function(res, header, value) {
-        if (typeof res.getHeader(header) === 'undefined') {
+        if (!res.headersSent && typeof res.getHeader(header) === 'undefined') {
           res.setHeader(header, value);
         }
       };

--- a/lib/context.js
+++ b/lib/context.js
@@ -92,16 +92,22 @@ Context.prototype.done = function(err, res) {
     }
 
     try {
-      this.res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-      this.res.setHeader("Pragma", "no-cache");
-      this.res.setHeader("Expires", "0");
+      var maybeSetHeader = function(res, header, value) {
+        if (typeof res.getHeader(header) === 'undefined') {
+          res.setHeader(header, value);
+        }
+      };
+
+      maybeSetHeader(this.res, "Cache-Control", "no-cache, no-store, must-revalidate");
+      maybeSetHeader(this.res, "Pragma", "no-cache");
+      maybeSetHeader(this.res, "Expires", "0");
       if(status != 204 && status != 304) {
         if(body) {
-          this.res.setHeader('Content-Length', Buffer.isBuffer(body)
+          maybeSetHeader(this.res, 'Content-Length', Buffer.isBuffer(body)
                ? body.length
                : Buffer.byteLength(body));
         }
-        this.res.setHeader('Content-Type', type);
+        maybeSetHeader(this.res, 'Content-Type', type);
         this.res.end(body);
       } else {
         this.res.end();

--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -106,7 +106,8 @@ exports.build = function(server, session, stack, ctx) {
           debug("Putting %s on stack", urlKey);
 
           res = {
-            setHeader: function() {},
+            getHeader: ctx.res.getHeader,
+            setHeader: ctx.res.setHeader,
             end: function(data) {
               if (res.statusCode === 200 || res.statusCode === 204) {
                 try {

--- a/lib/internal-client.js
+++ b/lib/internal-client.js
@@ -106,8 +106,8 @@ exports.build = function(server, session, stack, ctx) {
           debug("Putting %s on stack", urlKey);
 
           res = {
-            getHeader: ctx.res.getHeader,
-            setHeader: ctx.res.setHeader,
+            getHeader: function() {},
+            setHeader: function() {},
             end: function(data) {
               if (res.statusCode === 200 || res.statusCode === 204) {
                 try {

--- a/test/context.unit.js
+++ b/test/context.unit.js
@@ -15,4 +15,36 @@ describe('Context', function() {
       });
     });  
   });
+
+  describe('.done', function() {
+    it('should provide default headers', function(done) {
+      freq('/foo/bar', null, function(req, res) {
+        var r = new Resource('foo', {});
+        var ctx = new Context(r, req, res, {});
+        
+        var response = 'callback(123)';
+
+        ctx.done(null, response);
+        expect(ctx.res.getHeader('Content-Type')).to.equal('text/html; charset=utf-8');
+        expect(ctx.res.getHeader('Cache-Control')).to.equal('no-cache, no-store, must-revalidate');
+        expect(ctx.res.getHeader('Pragma')).to.equal('no-cache');
+        expect(ctx.res.getHeader('Expires')).to.equal('0');
+        expect(ctx.res.getHeader('Content-Length')).to.equal(response.length);
+
+        done();
+      });
+    });  
+
+    it('should not overwrite headers', function(done) {
+      freq('/foo/bar', null, function(req, res) {
+        var r = new Resource('foo', {});
+        var ctx = new Context(r, req, res, {});
+        
+        ctx.res.setHeader('Content-Type', 'text/javascript');
+        ctx.done(null, 'callback(123)');
+        expect(ctx.res.getHeader('Content-Type')).to.equal('text/javascript');
+        done();
+      });
+    });  
+  });
 });


### PR DESCRIPTION
## Description
This allows calling `ctx.res.setHeader('Content-Type', sometype)` from script code and ensuring deployd doesn't overwrite it.

## Motivation and Context
I needed to set the content type to 'text/javascript' for a particular response and it would get overwritten by a default.

## How Has This Been Tested?
Added tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)