### PR TITLE
Fix big numbers being parsed into integers when it wasn't safe to do so

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
 sudo: false
 services: mongodb
 node_js:
+  - "11"
+  - "10"
   - "9"
   - "8"
   - "7"

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -189,7 +189,7 @@ var parseNumbersInObject = function( obj ){
   for(key in obj){
     var val = obj[key];
     if(isInt.test(val)){
-      ret[key] = parseInt(val);
+      ret[key] = Number.isSafeInteger(parseInt(val)) ? parseInt(val) : '' + val;
     } else if(isFloat.test(val)){
       ret[key] = parseFloat(val);
     } else if (typeof val === 'object'){

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "shelljs": "^0.7.3",
     "socket.io": "^1.4.8",
     "underscore": "^1.8.3",
-    "validation": "*"
+    "validation": "0.0.1"
   },
   "devDependencies": {
-    "chai": "*",
+    "chai": "^4.2.0",
     "deployd-cli": "^2.0.0",
-    "less": "*",
-    "mocha": "*",
+    "less": "^3.9.0",
+    "mocha": "^5.2.0",
     "mocha-jshint": "2.3.1",
     "mocha-phantomjs": "^4.1.0",
     "rewire": "~2.5.2",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -6,5 +6,10 @@
     "dpd-dashboard": "*",
     "dpd-clientlib": "*"
   },
-  "dpdInclude": ["hello", "proxy", "dpd-clientlib", "dpd-dashboard"]
+  "dpdInclude": [
+    "hello",
+    "proxy",
+    "dpd-clientlib",
+    "dpd-dashboard"
+  ]
 }

--- a/test/support.js
+++ b/test/support.js
@@ -39,11 +39,11 @@ freq = function(url, options, fn, callback) {
   })
   .listen(port)
   .on('listening', function () {
-    if (callback) {
-      request(options, function(){
+    request(options, function (){
+      if (callback) {
         callback.apply(null, arguments);
-      });
-    }
+      }
+    });
   });
 };
 

--- a/test/support.js
+++ b/test/support.js
@@ -39,9 +39,11 @@ freq = function(url, options, fn, callback) {
   })
   .listen(port)
   .on('listening', function () {
-    request(options, function(){
-      callback.apply(null, arguments);
-    });
+    if (callback) {
+      request(options, function(){
+        callback.apply(null, arguments);
+      });
+    }
   });
 };
 

--- a/test/util.unit.js
+++ b/test/util.unit.js
@@ -26,125 +26,125 @@ describe('http', function() {
 		it('should parse a json query string', function() {
 			var q = http.parseQuery('/foo/bar?{"foo":"bar"}');
 			expect(q).to.eql({foo:'bar'});
-    });
-    
-    it('should not change a big number', function() {
-      var q = http.parseQuery('/foo/bar?id=9979174442646823');
-      // this number is expected to be changed by parseInt to 9979174442646824
+		});
+
+		it('should not change a big number', function() {
+			var q = http.parseQuery('/foo/bar?id=9979174442646823');
+			// this number is expected to be changed by parseInt to 9979174442646824
 			expect(q).to.eql({id:'9979174442646823'});
-    });
+		});
 	});
 
 describe('.getBody', function(){
 
-  it('should get body from stream', function(done){
+	it('should get body from stream', function(done){
 
-    var obj = JSON.stringify({foo: 'bar'})
-      , req = new Stream();
+		var obj = JSON.stringify({foo: 'bar'})
+			, req = new Stream();
 
-    var res = this.res;
+		var res = this.res;
 
-    http.getBody(req, function(buffer) {
-      expect(buffer).to.exist;
-      expect(buffer).to.eql(obj);
-      done();
-    });
+		http.getBody(req, function(buffer) {
+			expect(buffer).to.exist;
+			expect(buffer).to.eql(obj);
+			done();
+		});
 
-    req.emit('data', obj);
-    req.emit('end');
+		req.emit('data', obj);
+		req.emit('end');
 
-  });
+	});
 
-  it('should get body from rawBody', function(done){
+	it('should get body from rawBody', function(done){
 
-    var obj = JSON.stringify({foo: 'bar'})
-      , req = new Stream();
+		var obj = JSON.stringify({foo: 'bar'})
+			, req = new Stream();
 
-    req.rawBody = '';
-    req.on('data', function(chunk){
-      req.rawBody += chunk;
-    });
+		req.rawBody = '';
+		req.on('data', function(chunk){
+			req.rawBody += chunk;
+		});
 
-    var res = this.res;
+		var res = this.res;
 
-    req.on('end', function(){
-      http.getBody(req, function(buffer) {
-        expect(buffer).to.exist;
-        expect(buffer).to.eql(obj);
-        done();
-      });
-    });
+		req.on('end', function(){
+			http.getBody(req, function(buffer) {
+				expect(buffer).to.exist;
+				expect(buffer).to.eql(obj);
+				done();
+			});
+		});
 
-    req.emit('data', obj);
-    req.emit('end');
+		req.emit('data', obj);
+		req.emit('end');
 
-  });
+	});
 
 });
 
 describe('.parseBody()', function() {
-  beforeEach(function () {
-    this.res = {
-      setHeader: function () {
+	beforeEach(function () {
+		this.res = {
+			setHeader: function () {
 
-      }
-    };
-  });
+			}
+		};
+	});
 
-  it ('should parse json', function(done) {
-    var obj = {foo: 'bar'}
-      , req = new Stream();
+	it ('should parse json', function(done) {
+		var obj = {foo: 'bar'}
+			, req = new Stream();
 
-    http.parseBody(req, this.res, 'application/json', function(err, result) {
-      expect(err).to.not.exist;
-      expect(req.body).to.eql(obj);
-      done();
-    });
-    req.emit('data', JSON.stringify(obj));
-    req.emit('end');
-  });
+		http.parseBody(req, this.res, 'application/json', function(err, result) {
+			expect(err).to.not.exist;
+			expect(req.body).to.eql(obj);
+			done();
+		});
+		req.emit('data', JSON.stringify(obj));
+		req.emit('end');
+	});
 
-  it('should parse json in chunks', function(done) {
-    var req = new Stream()
-      , chunks = ['{"fo'
-                , 'o": "bar"'
-                , ', "bar"'
-                , ': "baz"'
-                , '}'];
+	it('should parse json in chunks', function(done) {
+		var req = new Stream()
+			, chunks = ['{"fo'
+								, 'o": "bar"'
+								, ', "bar"'
+								, ': "baz"'
+								, '}'];
 
-    http.parseBody(req, this.res, 'application/json', function(err) {
-      expect(err).to.not.exist;
-      expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
-      done();
-    });
-    chunks.forEach(function(c) {
-      req.emit('data', c);
-    });
-    req.emit('end');
-  });
+		http.parseBody(req, this.res, 'application/json', function(err) {
+			expect(err).to.not.exist;
+			expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
+			done();
+		});
+		chunks.forEach(function(c) {
+			req.emit('data', c);
+		});
+		req.emit('end');
+	});
 
-  it('should parse a form url-encoded value', function(done) {
-    var value = "foo=bar&bar=baz"
-      , req = new Stream();
+	it('should parse a form url-encoded value', function(done) {
+		var value = "foo=bar&bar=baz"
+			, req = new Stream();
 
-    http.parseBody(req, this.res, 'application/x-www-form-urlencoded', function(err) {
-      expect(err).to.not.exist;
-      expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
-      done();
-    });
-    req.emit('data', value);
-    req.emit('end');
-  });
+		http.parseBody(req, this.res, 'application/x-www-form-urlencoded', function(err) {
+			expect(err).to.not.exist;
+			expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
+			done();
+		});
+		req.emit('data', value);
+		req.emit('end');
+	});
 
-  it('should interpret an empty body as an empty object', function(done) {
-    var req = new Stream();
+	it('should interpret an empty body as an empty object', function(done) {
+		var req = new Stream();
 
-    http.parseBody(req, this.res, 'application/json', function(err) {
-      expect(err).to.not.exist;
-      expect(req.body).to.eql({});
-      done();
-    });
-    req.emit('end');
-  });
+		http.parseBody(req, this.res, 'application/json', function(err) {
+			expect(err).to.not.exist;
+			expect(req.body).to.eql({});
+			done();
+		});
+		req.emit('end');
+	});
 });
 });

--- a/test/util.unit.js
+++ b/test/util.unit.js
@@ -26,7 +26,12 @@ describe('http', function() {
 		it('should parse a json query string', function() {
 			var q = http.parseQuery('/foo/bar?{"foo":"bar"}');
 			expect(q).to.eql({foo:'bar'});
-		});
+    });
+    
+    it('should not change a big number', function() {
+			var q = http.parseQuery('/foo/bar?id=9979174442646823');
+			expect(q).to.eql({id:'9979174442646823'});
+    });
 	});
 
 describe('.getBody', function(){

--- a/test/util.unit.js
+++ b/test/util.unit.js
@@ -1,150 +1,150 @@
 var http = require('../lib/util/http')
-	,	Stream = require('stream');
+  ,	Stream = require('stream');
 
 describe('uuid', function() {
-	describe('.create()', function() {
-		var uuid = require('../lib/util/uuid');
-		var used = {};
-		// max number of objects that must not conflict
-		// total of about 2 trillion possible combinations
-		var i = 1000; // replace this with a larger number to really test
-		while(i--) {
-			var next = uuid.create();
-			if(used[next]) throw 'already used';
-			used[next] = 1;
-		}
-	});
+  describe('.create()', function() {
+    var uuid = require('../lib/util/uuid');
+    var used = {};
+    // max number of objects that must not conflict
+    // total of about 2 trillion possible combinations
+    var i = 1000; // replace this with a larger number to really test
+    while(i--) {
+      var next = uuid.create();
+      if(used[next]) throw 'already used';
+      used[next] = 1;
+    }
+  });
 });
 
 describe('http', function() {
-	describe('.parseQuery', function() {
-		it('should parse a query string', function() {
-			var q = http.parseQuery('/foo/bar?foo=bar');
-			expect(q).to.eql({foo:'bar'});
-		});
+  describe('.parseQuery', function() {
+    it('should parse a query string', function() {
+      var q = http.parseQuery('/foo/bar?foo=bar');
+      expect(q).to.eql({foo:'bar'});
+    });
 
-		it('should parse a json query string', function() {
-			var q = http.parseQuery('/foo/bar?{"foo":"bar"}');
-			expect(q).to.eql({foo:'bar'});
-		});
+    it('should parse a json query string', function() {
+      var q = http.parseQuery('/foo/bar?{"foo":"bar"}');
+      expect(q).to.eql({foo:'bar'});
+    });
 
-		it('should not change a big number', function() {
-			var q = http.parseQuery('/foo/bar?id=9979174442646823');
-			// this number is expected to be changed by parseInt to 9979174442646824
-			expect(q).to.eql({id:'9979174442646823'});
-		});
-	});
+    it('should not change a big number', function() {
+      var q = http.parseQuery('/foo/bar?id=9979174442646823');
+      // this number is expected to be changed by parseInt to 9979174442646824
+      expect(q).to.eql({id:'9979174442646823'});
+    });
+  });
 
 describe('.getBody', function(){
 
-	it('should get body from stream', function(done){
+  it('should get body from stream', function(done){
 
-		var obj = JSON.stringify({foo: 'bar'})
-			, req = new Stream();
+    var obj = JSON.stringify({foo: 'bar'})
+      , req = new Stream();
 
-		var res = this.res;
+    var res = this.res;
 
-		http.getBody(req, function(buffer) {
-			expect(buffer).to.exist;
-			expect(buffer).to.eql(obj);
-			done();
-		});
+    http.getBody(req, function(buffer) {
+      expect(buffer).to.exist;
+      expect(buffer).to.eql(obj);
+      done();
+    });
 
-		req.emit('data', obj);
-		req.emit('end');
+    req.emit('data', obj);
+    req.emit('end');
 
-	});
+  });
 
-	it('should get body from rawBody', function(done){
+  it('should get body from rawBody', function(done){
 
-		var obj = JSON.stringify({foo: 'bar'})
-			, req = new Stream();
+    var obj = JSON.stringify({foo: 'bar'})
+      , req = new Stream();
 
-		req.rawBody = '';
-		req.on('data', function(chunk){
-			req.rawBody += chunk;
-		});
+    req.rawBody = '';
+    req.on('data', function(chunk){
+      req.rawBody += chunk;
+    });
 
-		var res = this.res;
+    var res = this.res;
 
-		req.on('end', function(){
-			http.getBody(req, function(buffer) {
-				expect(buffer).to.exist;
-				expect(buffer).to.eql(obj);
-				done();
-			});
-		});
+    req.on('end', function(){
+      http.getBody(req, function(buffer) {
+        expect(buffer).to.exist;
+        expect(buffer).to.eql(obj);
+        done();
+      });
+    });
 
-		req.emit('data', obj);
-		req.emit('end');
+    req.emit('data', obj);
+    req.emit('end');
 
-	});
+  });
 
 });
 
 describe('.parseBody()', function() {
-	beforeEach(function () {
-		this.res = {
-			setHeader: function () {
+  beforeEach(function () {
+    this.res = {
+      setHeader: function () {
 
-			}
-		};
-	});
+      }
+    };
+  });
 
-	it ('should parse json', function(done) {
-		var obj = {foo: 'bar'}
-			, req = new Stream();
+  it ('should parse json', function(done) {
+    var obj = {foo: 'bar'}
+      , req = new Stream();
 
-		http.parseBody(req, this.res, 'application/json', function(err, result) {
-			expect(err).to.not.exist;
-			expect(req.body).to.eql(obj);
-			done();
-		});
-		req.emit('data', JSON.stringify(obj));
-		req.emit('end');
-	});
+    http.parseBody(req, this.res, 'application/json', function(err, result) {
+      expect(err).to.not.exist;
+      expect(req.body).to.eql(obj);
+      done();
+    });
+    req.emit('data', JSON.stringify(obj));
+    req.emit('end');
+  });
 
-	it('should parse json in chunks', function(done) {
-		var req = new Stream()
-			, chunks = ['{"fo'
-								, 'o": "bar"'
-								, ', "bar"'
-								, ': "baz"'
-								, '}'];
+  it('should parse json in chunks', function(done) {
+    var req = new Stream()
+      , chunks = ['{"fo'
+                , 'o": "bar"'
+                , ', "bar"'
+                , ': "baz"'
+                , '}'];
 
-		http.parseBody(req, this.res, 'application/json', function(err) {
-			expect(err).to.not.exist;
-			expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
-			done();
-		});
-		chunks.forEach(function(c) {
-			req.emit('data', c);
-		});
-		req.emit('end');
-	});
+    http.parseBody(req, this.res, 'application/json', function(err) {
+      expect(err).to.not.exist;
+      expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
+      done();
+    });
+    chunks.forEach(function(c) {
+      req.emit('data', c);
+    });
+    req.emit('end');
+  });
 
-	it('should parse a form url-encoded value', function(done) {
-		var value = "foo=bar&bar=baz"
-			, req = new Stream();
+  it('should parse a form url-encoded value', function(done) {
+    var value = "foo=bar&bar=baz"
+      , req = new Stream();
 
-		http.parseBody(req, this.res, 'application/x-www-form-urlencoded', function(err) {
-			expect(err).to.not.exist;
-			expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
-			done();
-		});
-		req.emit('data', value);
-		req.emit('end');
-	});
+    http.parseBody(req, this.res, 'application/x-www-form-urlencoded', function(err) {
+      expect(err).to.not.exist;
+      expect(req.body).to.eql({"foo": "bar", "bar": "baz"});
+      done();
+    });
+    req.emit('data', value);
+    req.emit('end');
+  });
 
-	it('should interpret an empty body as an empty object', function(done) {
-		var req = new Stream();
+  it('should interpret an empty body as an empty object', function(done) {
+    var req = new Stream();
 
-		http.parseBody(req, this.res, 'application/json', function(err) {
-			expect(err).to.not.exist;
-			expect(req.body).to.eql({});
-			done();
-		});
-		req.emit('end');
-	});
+    http.parseBody(req, this.res, 'application/json', function(err) {
+      expect(err).to.not.exist;
+      expect(req.body).to.eql({});
+      done();
+    });
+    req.emit('end');
+  });
 });
 });

--- a/test/util.unit.js
+++ b/test/util.unit.js
@@ -29,7 +29,8 @@ describe('http', function() {
     });
     
     it('should not change a big number', function() {
-			var q = http.parseQuery('/foo/bar?id=9979174442646823');
+      var q = http.parseQuery('/foo/bar?id=9979174442646823');
+      // this number is expected to be changed by parseInt to 9979174442646824
 			expect(q).to.eql({id:'9979174442646823'});
     });
 	});


### PR DESCRIPTION
I had a generated row id of 9979174442646823 which when converted to a number by `parseInt('9979174442646823')` would get changed to 9979174442646824, resulting in undefined behavior.

This only affected query string based parameter passing. JSON in POST body is unaffected.

Also fixed other failing tests.